### PR TITLE
Combines web-wide and site-specific APIs

### DIFF
--- a/drafts/tracking-dnt.html
+++ b/drafts/tracking-dnt.html
@@ -1869,8 +1869,8 @@ object {
         <code>weather.example.com</code>, respectively. 
       </p>
     </section>
-       <section id="exception-javascript-api">
-      <h3>Site-specific Exception</h3>
+        <section id="exception-javascript-api">
+      <h3>Exception API</h3>
 
       <p class="ednote">
         We currently specify six different APIs (plus the doNotTrack property
@@ -1879,7 +1879,7 @@ object {
         single (inappropriate) exception to signal all errors.<br />
         <br />
         What we should have is one exception record and three APIs for
-        store/confirm/delete with a single Promise<void> return type and
+        store/confirm/delete with a single Promise&lt;T&gt; return type and
         a distinct exception name for each error. The interfaces should be
         defined using an algorithm similar to other specifications of
         promise-based interfaces. We should also remove the expires field
@@ -1887,317 +1887,368 @@ object {
         is only kept in HTTP for legacy reasons.
       </p>
 
-      <section id="exception-javascript-api-rqst">
-        <h4>API to Request a Site-specific Exception</h4>
+        <section id="exception-javascript-api-rqst">
+            <h4>API to Request a Tracking Exception</h4>
 
-        <p>
-          <code><dfn>Navigator.storeSiteSpecificTrackingException</dfn></code>
-          is called by a page to store a site-specific tracking exception.
-          A <code><dfn>StoreExceptionPropertyBag</dfn></code> dictionary
-          contains the information to be stored for that exception.
-  It returns a <code>Promise</code> resolving to a <code><dfn>StoreExceptionResult</dfn></code> result object.
-        </p>
-        <pre class="idl overlarge">
+            <p>
+                <code><dfn>Navigator.storeTrackingException</dfn></code>
+                is called by a page to store a tracking exception,
+                which can be site-specific, site-wide site-specific, or web-wide.
+                A <code><dfn>StoreExceptionPropertyBag</dfn></code> dictionary
+                contains the information to be stored for that exception.
+                It returns a <code>Promise</code> which either resolves to an <code><dfn>ExceptionResult</dfn></code> result,
+                or is rejected with a <code>DOMException</code> identifying the reason for the failure.
+            </p>
+            <pre class="idl overlarge">
         partial interface Navigator {
-            Promise&lt;StoreExceptionResult&gt; storeSiteSpecificTrackingException (
+            Promise&lt;ExceptionResult&gt; storeTrackingException (
             StoreExceptionPropertyBag properties
             );
         };
-
         dictionary StoreExceptionPropertyBag {
            DOMString? domain;
+           boolean? isWebWide;
+           sequence&lt;DOMString&gt;? arrayOfDomainStrings;
            DOMString? siteName;
            DOMString? explanationString;
            DOMString? detailURI;
            DOMString? expires;
            long?      maxAge;
-           sequence&lt;DOMString&gt; arrayOfDomainStrings;
         };
-
-        dictionary StoreExceptionResult {
-          boolean siteWide;
+        dictionary ExceptionResult {
+          boolean? isSiteWide;
+          boolean? exists;
         };
         </pre>
-        <p>
-          <a>Navigator.storeSiteSpecificTrackingException</a> passes a
-          <a>StoreExceptionPropertyBag</a> that can contain the following
-          properties:
-        </p>
-        <dl data-dfn-for="StoreExceptionPropertyBag">
-          <dt><code><dfn>domain</dfn></code></dt>
-          <dd>a cookie-domain as defined in [[!RFC6265]],
-              to which the exception applies.</dd>
-          <dt><code><dfn>siteName</dfn></code></dt>
-          <dd>A user-readable string for the name of the top-level origin.</dd>
-          <dt><code><dfn>explanationString</dfn></code></dt>
-          <dd>A short explanation of the request.</dd>
-          <dt><code><dfn>detailURI</dfn></code></dt>
-          <dd>A location at which further information about this request
-              can be found.</dd>
-          <dt><code><dfn>expires</dfn></code></dt>
-          <dd>A date and time, encoded as described for the cookie
-              <code>Expires</code> attribute described in [[RFC6265]],
-              indicating the maximum lifetime of the remembered grant.</dd>
-          <dt><code><dfn>maxAge</dfn></code></dt>
-          <dd>A positive number of seconds indicating the maximum lifetime
-              of the remembered grant.</dd>
-          <dt><code><dfn>arrayOfDomainStrings</dfn></code></dt>
-          <dd>A JavaScript array of strings.</dd>
-        </dl>
-        <p>
-          Calling <code>storeSiteSpecificTrackingException</code> returns a
-          <code>Promise</code> which either resolves to a
-          <code>StoreExceptionResult</code> object, or is rejected with a
-          <code>DOMException</code> SYNTAX_ERR result. The
-          <code>Promise</code> resolves immediately the Tracking Exception
-          request has been processed, with the property
-          <code><dfn>siteWide</dfn></code> set to <code>true</code> if the
-          exception is site-wide.
-        </p>
-        <p>
-          If the request does not include the
-          <code>arrayOfDomainStrings</code>, then this request is for a
-          site-wide exception. Otherwise each string in
-          <code>arrayOfDomainStrings</code> specifies a
-          <a>target domain</a>.
-        </p>
-        <p>
-          If the list <code>arrayOfDomainStrings</code> is supplied, the
-          user agent MAY choose to store a site-wide exception. If it does
-          so it MUST indicate this by setting the <code>siteWide</code> property to <code>true</code>.
-        </p>
-        <p>
-          If <code>domain</code> is not specified or is null or empty then
-          the <a>script domain</a> is used instead.
-        </p>
-        <p>
-          If an exception is stored for an explicit list, then the set of
-          duplets (one per <a>target domain</a>):
-        </p>
-        <pre>[<a>script domain</a>, <a>target domain</a>]</pre>
-        <p>
-          is added to the database of remembered grants.
-        </p>
-        <p>
-          If an exception is stored for a site-wide exception, then the
-          duplet:
-        </p>
-        <pre>[<a>script domain</a>, * ]</pre>
-        <p>
-          is added to the database of remembered grants.
-        </p>
-        <p>
-          If <code>domain</code> is supplied and not empty then it is
-          treated in the same way as the domain parameter to cookies and
-          allows setting for subdomains. The <code>domain</code> argument
-          can be set to a fully-qualified right-hand segment of the document
-          host name, up to one level below TLD.
-        </p>
-        <p>
-          For example, <em>www.foo.bar.example.com</em> can set the domain
-          parameter as as <code>"bar.example.com"</code> or
-          <code>"example.com"</code>, but not to
-          <code>"something.else.example.com"</code> or <code>"com"</code>.
-        </p>
-        <p>
-          If the <a>effective script origin</a> would not be able to set a
-          cookie on the <code>domain</code> following the cookie domain rules
-          [[!RFC6265]] (e.g. <code>domain</code> is not a right-hand match or
-          is a TLD)
-          then the duplet MUST NOT be entered into the database and the
-          returned <code>Promise</code> MUST be
-          rejected with a <code>DOMException</code> SYNTAX_ERR.
-        </p>
-        <p>
-          If an exception is stored for an explicit list, then the set of
-          duplets (one per <a>target domain</a>):
-        </p>
-        <pre>[*.domain, <a>target domain</a>]</pre>
-        <p>
-          is added to the database of remembered grants.
-        </p>
-        <p>
-          If an exception is stored for a site-wide exception, then the
-          duplet:
-        </p>
-        <pre>[*.domain, * ]</pre>
-        <p>
-          is added to the database of remembered grants.
-        </p>
-        <p>
-          A particular response to the API &mdash; like a DNT response header
-          field &mdash; is only valid immediately; a user might later choose
-          to edit stored exceptions and revoke some or all of them.
-        </p>
-        <p>
-          If <code>expires</code> is supplied and not null or empty the
-          remembered grant will be cancelled (i.e. processed as if the
-          relevant Cancel API had been called) no later than the specified
-          date and time.
-        </p>
-        <p>
-          If <code>maxAge</code> is supplied and not null, empty or negative
-          the remembered grant will be cancelled (i.e. processed as if the
-          relevant Cancel API had been called) no later than the specified
-          number of seconds following the grant.
-        </p>
-        <p>
-          If both <code>maxAge</code> and <code>expires</code> are supplied,
-          <code>maxAge</code> has precedence. If neither <code>maxAge</code>
-          or <code>expires</code> are supplied, the user agent MAY retain
-          the remembered grant until it is cancelled.
-        </p>
-      </section>
+            <p>
+                <a>Navigator.storeTrackingException</a> passes a
+                <a>StoreExceptionPropertyBag</a> that can contain the following
+                properties:
+            </p>
+            <dl data-dfn-for="StoreExceptionPropertyBag">
+                <dt><code><dfn>isWebWide</dfn></code></dt>
+                <dd>A boolean specifying this request to be for a web-wide exception. If <code>isWebWide</code> is empty, <code>false</code> or <code>null</code> this is for a site-specific exception</dd>
+                <dt><code><dfn>domain</dfn></code></dt>
+                <dd>
+                    a cookie-domain as defined in [[!RFC6265]],
+                    to which the exception applies.
+                </dd>
+                <dt><code><dfn>arrayOfDomainStrings</dfn></code></dt>
+                <dd>A JavaScript array of strings.</dd>
+                <dt><code><dfn>siteName</dfn></code></dt>
+                <dd>A user-readable string for the name of the top-level origin.</dd>
+                <dt><code><dfn>explanationString</dfn></code></dt>
+                <dd>A short explanation of the request.</dd>
+                <dt><code><dfn>detailURI</dfn></code></dt>
+                <dd>
+                    A location at which further information about this request
+                    can be found.
+                </dd>
+                <dt><code><dfn>expires</dfn></code></dt>
+                <dd>
+                    A date and time, encoded as described for the cookie
+                    <code>Expires</code> attribute described in [[RFC6265]],
+                    indicating the maximum lifetime of the remembered grant.
+                </dd>
+                <dt><code><dfn>maxAge</dfn></code></dt>
+                <dd>
+                    A positive number of seconds indicating the maximum lifetime
+                    of the remembered grant.
+                </dd>
+            </dl>
+            <p>
+                Calling <code>storeTrackingException</code> returns a
+                <code>Promise</code> which either resolves to an
+                <code><a>ExceptionResult</a></code> object, or is rejected with a
+                <code>DOMException</code> result. The
+                <code>Promise</code> resolves immediately the Tracking Exception
+                request has been processed, with the property
+                <code>isSiteWide</code> set to <code>true</code> if the
+                request was for a site-specific exception and the resulting operation is site-wide.
+            </p>
+            <p>
+                If the request is for a site-specific exception and it does not include the
+                <code>arrayOfDomainStrings</code>, then this request is for a
+                site-wide, site-specific  exception. Otherwise each string in
+                <code>arrayOfDomainStrings</code> specifies a
+                <a>target domain</a>.
+            </p>
+            <p>
+                If the list <code>arrayOfDomainStrings</code> is supplied and the request is for a site-specific exception, the
+                user agent MAY choose to store a site-wide, site-specific exception. If it does
+                so it MUST indicate this by setting the <code>isSiteWide</code> property to <code>true</code>.
+            </p>
+            <p>
+                If <code>domain</code> is supplied and not empty then it is
+                treated in the same way as the domain parameter to cookies and
+                allows setting for subdomains. The <code>domain</code> argument
+                can be set to a fully-qualified right-hand segment of the document
+                host name, up to one level below TLD.
+                In the description below the variable <em>Domain</em> would have the value <code>*.domain</code>
+            </p>
+            <p>
+                For example, <em>www.foo.bar.example.com</em> can set the domain
+                parameter as as <code>"bar.example.com"</code> or
+                <code>"example.com"</code>, but not to
+                <code>"something.else.example.com"</code> or <code>"com"</code>.
+            </p>
+            <p>
+                If <code>domain</code> is not specified or is null or empty then the request would be processed as if it had been set to
+                the <a>script domain</a>.
+                In the description below the variable <em>Domain</em> would have the value <a>script domain</a>
+            </p>
+            <p>
+                If <code>isWebWide</code> is not <code>true</code> and the exception is stored for an explicit list, then the set of
+                duplets (one per <a>target domain</a>):
+            </p>
+            <pre>[Domain, target domain]</pre>
+            <p>
+                is added to the database of remembered grants.
+            </p>
+            <p>
+                If <code>isWebWide</code> is not <code>true</code> and the exception is stored for a site-wide exception, then the
+                duplet:
+            </p>
+            <pre>[Domain, * ]</pre>
+            <p>
+                is added to the database of remembered grants.
+            </p>
+            <p>
+                If <code>isWebWide</code> is not <code>true</code> and the exception is stored for an explicit list, then the set of
+                duplets (one per <a>target domain</a>):
+            </p>
+            <pre>[Domain, target domain]</pre>
+            <p>
+                is added to the database of remembered grants.
+            </p>
+            <p>
+                If <code>isWebWide</code> is <code>true</code> then this request is for a Web-Wide Exception and the
+                duplet:
+            </p>
+            <pre>[*, Domain]</pre>
+            <p>
+                is added to the database of remembered grants.
+            </p>
+
+            <p>
+                If <code>expires</code> is supplied and not null or empty the
+                remembered grant will be cancelled (i.e. processed as if the
+                relevant Cancel API had been called) no later than the specified
+                date and time.
+            </p>
+            <p>
+                If <code>maxAge</code> is supplied and not null, empty or negative
+                the remembered grant will be cancelled (i.e. processed as if the
+                relevant Cancel API had been called) no later than the specified
+                number of seconds following the grant.
+            </p>
+            <p>
+                If both <code>maxAge</code> and <code>expires</code> are supplied,
+                <code>maxAge</code> has precedence. If neither <code>maxAge</code>
+                or <code>expires</code> are supplied, the user agent MAY retain
+                the remembered grant until it is cancelled.
+            </p>
+            <p>
+                If the <a>effective script origin</a> would not be able to set a
+                cookie on the <code>domain</code> following the cookie domain rules
+                [[!RFC6265]] (e.g. <code>domain</code> is not a right-hand match or
+                is a TLD)
+                then the duplet MUST NOT be entered into the database and the
+                returned <code>Promise</code> MUST be
+                rejected with a <code>DOMException.SECURITY_ERR</code>.
+            </p>
+            <p>
+                Any other failuure, such as an incorrectly formatted parameter in the <a>StoreExceptionPropertyBag</a>,
+                will result in no duplet being added to the data base of remebered grants, and
+                the returned <code>Promise</code> being
+                rejected with a <code>DOMException.SYNTAX_ERR</code>.
+            </p>
+            <p>
+                A particular response to the API &mdash; like a DNT response header
+                field &mdash; is only valid immediately; a user might later choose
+                to edit stored exceptions and revoke some or all of them.
+            </p>
+        </section>
 
       <section id="exception-javascript-api-cancel">
-        <h4>API to Cancel a Site-specific Exception</h4>
+        <h4>API to Cancel a Tracking Exception</h4>
 
         <p>
-          <code><dfn>Navigator.removeSiteSpecificTrackingException</dfn></code>
-          is called by a page to cancel a site-specific tracking exception.
-          A <code><dfn>RemoveExceptionPropertyBag</dfn></code> dictionary
+          <code><dfn>Navigator.removeTrackingException</dfn></code>
+          is called by a page to cancel a site-specific or web-wide tracking exception.
+          The <code><dfn>RemoveExceptionPropertyBag</dfn></code> dictionary
           contains information to identify the exception.
         </p>
         <pre class="idl overlarge">
         partial interface Navigator {
-          Promise&lt;void&gt; removeSiteSpecificTrackingException (
+          Promise&lt;void&gt; removeTrackingException (
             RemoveExceptionPropertyBag properties
           );
         };
 
         dictionary RemoveExceptionPropertyBag {
-          DOMString? domain;
+           DOMString? domain;
+           boolean? isWebWide;
         };
+
         </pre>
-        <p>
-          <a>Navigator.removeSiteSpecificTrackingException</a> passes a
-          <a>RemoveExceptionPropertyBag</a> that can contain the following
-          property:
-        </p>
-        <dl data-dfn-for="RemoveExceptionPropertyBag">
-          <dt><code><dfn>domain</dfn></code></dt>
-          <dd>a cookie-domain as defined in [[!RFC6265]],
-              to which the exception applies.</dd>
-        </dl>
-        <p>
-          If domain is not supplied or is null or empty then
-          the <a>script domain</a> is used instead. This asks for
-          removal of all duplets in the grant database for which the first
-          part matches the <a>script domain</a>; i.e., no duplets
-          <code>[<a>script domain</a>, <a>target domain</a>]</code>
-          for any <a>target domain</a>.
-        </p>
-        <p>
-          If domain is supplied and is not empty then this ensures that
-          the database of remembered grants no longer contains any
-          duplets for which the first part is the domain wildcard; i.e.,
-          no duplets <code>[*.domain, <a>target domain</a>]</code>
-          for any <a>target domain</a>.
-        </p>
-        <p>
-          A <code>Promise</code> resolving to <code>void</code> is returned.
+          <p>
+              <a>Navigator.removeTrackingException</a> passes a
+              <a>RemoveExceptionPropertyBag</a> that can contain the following
+              properties:
+          </p>
+          <dl data-dfn-for="RemoveExceptionPropertyBag">
+              <dt><code><dfn>isWebWide</dfn></code></dt>
+              <dd>
+                  A boolean specifying whether a web-wide or a site-specific exception should be removed.
+                  If <code>isWebWide</code> is empty, <code>false</code> or <code>null</code> this call refers to a site-specific exception
+              </dd>
+              <dt><code><dfn>domain</dfn></code></dt>
+              <dd>
+                  a cookie-domain as defined in [[!RFC6265]],
+                  to which the exception applies.
+              </dd>
+          </dl>
+          <p>
+              If <code>domain</code> is supplied and not empty then it is
+              treated in the same way as the domain parameter to cookies and
+              allows setting for subdomains. The <code>domain</code> argument
+              can be set to a fully-qualified right-hand segment of the document
+              host name, up to one level below TLD.
+              In the description below the variable <em>Domain</em> would have the value <code>*.domain</code>
+          </p>
+          <p>
+              If <code>domain</code> is not specified or is null or empty then the request would be processed as if it had been set to
+              the <a>script domain</a>.
+              In the description below the variable <em>Domain</em> would have the value <a>script domain</a>
+          </p>
+          <p>
+              The return value is a <code>Promise</code> which either resolves to a <code>void</code> result,
+              or is rejected with a <code>DOMException</code>.
+          </p>
+          <p>
+              Any processing failure, such as an incorrectly formatted parameter in the <a>RemoveExceptionPropertyBag</a>,
+              will result in no duplet being removed from the data base of remebered grants, and
+              the returned <code>Promise</code> being
+              rejected with a <code>DOMException.SYNTAX_ERR</code>.
+          </p>
+          <p>
           When the <code>Promise</code> has been resolved, it is assumed
-          that there are no site-specific or site-wide exceptions for the
-          given top-level origin.
+          that there are no exceptions of the specified type for the
+          given <a>Domain</a>, and the database of
+          grants no longer contains the indicated grant(s); 
         </p>
-        <p>
-          When the returned <code>Promise</code> is resolved, the database of
-          grants no longer contains the indicated grant(s); if some kind of
-          processing error occurred then an appropriate exception will be
-          thrown.
-        </p>
-        <p>
-          If there are no matching duplets in the database of remembered
-          grants when the method is called then this operation does nothing
-          (and does not throw an exception).
-        </p>
+          <p>
+              If there are no matching duplets in the database of remembered
+              grants when the method is called then this operation does nothing,
+              other than resolving the <code>Promise</code>.
+          </p>
+
       </section>
 
       <section id="exception-javascript-api-confirm">
-        <h4>API to Confirm a Site-specific Exception</h4>
+        <h4>API to Confirm a Tracking Exception</h4>
 
         <p>
-          <code><dfn>Navigator.confirmSiteSpecificTrackingException</dfn></code>
-          is called by a page to confirm a site-specific exception.
-          A <code><dfn>ConfirmExceptionPropertyBag</dfn></code> dictionary
+          <code><dfn>Navigator.confirmTrackingException</dfn></code>
+          is called by a page to confirm a tracking exception.
+          A <code><dfn>ExceptionPropertyBag</dfn></code> dictionary
           contains information to identify the exception.
-          It returns a <code>Promise</code> resolving to a <code><dfn>ConfirmExceptionResult</dfn></code>
-  result object.
+          It returns a <code>Promise</code> which either resolves to an <code><dfn>ExceptionResult</dfn></code> result,
+            or is rejected with a <code>DOMException</code> identifying the reason for the failure.
         </p>
         <pre class="idl overlarge">
         partial interface Navigator {
-          Promise&lt;ConfirmExceptionResult&gt; confirmSiteSpecificTrackingException (
+          Promise&lt;ExceptionResult&gt; confirmSiteSpecificTrackingException (
             ConfirmExceptionPropertyBag properties
           );
         };
 
         dictionary ConfirmExceptionPropertyBag {
-          DOMString? domain;
-          sequence&lt;DOMString&gt; arrayOfDomainStrings;
+           DOMString? domain;
+           boolean? isWebWide;
+           sequence&lt;DOMString&gt;? arrayOfDomainStrings;
         };
 
-        dictionary ConfirmExceptionResult {
-          boolean exists;
-        };
         </pre>
         <p>
           <a>Navigator.confirmSiteSpecificTrackingException</a> passes a
           <a>ConfirmExceptionPropertyBag</a> that can contain the following
           properties:
         </p>
-        <dl data-dfn-for="ConfirmExceptionPropertyBag">
-          <dt><code><dfn>domain</dfn></code></dt>
-          <dd>a cookie-domain as defined in [[!RFC6265]],
-              to which the exception applies.</dd>
-          <dt><code><dfn>arrayOfDomainStrings</dfn></code></dt>
-          <dd>A JavaScript array of strings.</dd>
-        </dl>
+          <dl data-dfn-for="ConfirmExceptionPropertyBag">
+              <dt><code><dfn>isWebWide</dfn></code></dt>
+              <dd>
+                  A boolean specifying whether a web-wide or a site-specific exception should be confirmed
+                  If <code>isWebWide</code> is empty, <code>false</code> or <code>null</code> this call refers to a site-specific exception
+              </dd>
+              <dt><code><dfn>domain</dfn></code></dt>
+              <dd>
+                  a cookie-domain as defined in [[!RFC6265]],
+                  to which the exception applies.
+              </dd>
+              <dt><code><dfn>arrayOfDomainStrings</dfn></code></dt>
+              <dd>A JavaScript array of strings.</dd>
+          </dl>
         <p>
-          If the call does not include the
+          If <code>isWebWide</code> is not <code>true</code> and the call does not include the
           <code>arrayOfDomainStrings</code>, then this call is to confirm a
           site-wide exception. Otherwise each string in
           <code>arrayOfDomainStrings</code> specifies a
           <a>target domain</a>.
         </p>
+          <p>
+              If <code>isWebWide</code> is not <code>true</code>, the list <code>arrayOfDomainStrings</code> is supplied, and the
+              user agent stores only site-wide exceptions, then the user agent
+              MUST match by confirming a site-wide exception.
+          </p>
+          <p>
+              If <code>domain</code> is supplied and not empty then it is
+              treated in the same way as the domain parameter to cookies and
+              allows setting for subdomains. The <code>domain</code> argument
+              can be set to a fully-qualified right-hand segment of the document
+              host name, up to one level below TLD.
+              In the description below the variable <em>Domain</em> would have the value <code>*.domain</code>
+          </p>
+          <p>
+              If <code>domain</code> is not specified or is null or empty then the request would be processed as if it had been set to
+              the <a>script domain</a>.
+              In the description below the variable <em>Domain</em> would have the value <a>script domain</a>
+          </p>
+          <p>
+              If <code>isWebWide</code> is <code>true</code> then any <code>arrayOfDomainStrings</code> is ignored, and
+              the user agent MUST match by confirming a web-wide exception, i.e. the database is checked for the duplet:
+
+          </p>
+          <pre>[*,Domain]</pre>
         <p>
-          If the list <code>arrayOfDomainStrings</code> is supplied, and the
-          user agent stores only site-wide exceptions, then the user agent
-          MUST match by confirming a site-wide exception.
-        </p>
-        <p>
-          If the <code>domain</code> argument is not supplied or is null or
-          empty then the <a>script domain</a> is used instead.
-        </p>
-        <p>
-          If the user agent stores explicit lists, and the call includes
-          one, the database is checked for the existence of all the duplets
+          If the user agent stores explicit lists, <code>isWebWide</code> is not <code>true</code> and the call includes
+          an  <code>arrayOfDomainStrings</code>, the database is checked for the existence of all the duplets
           (one per target):
         </p>
-        <pre>[script domain, target]</pre>
+        <pre>[Domain, target domain]</pre>
         <p>
-          If the user agent stores only site-wide exceptions or the call did
+          If <code>isWebWide</code> is not <code>true</code>, the user agent stores only site-wide exceptions or the call did
           not include an explicit list, the database is checked for the
           single duplet:
         </p>
-        <pre>[script domain, * ]</pre>
+        <pre>[Domain, * ]</pre>
         <p>
-          If the user agent stores explicit lists, the call includes
-          one, and the <code>domain</code> argument is provided and is not
-          empty, then the database is checked for the existence of all the
+          If <code>isWebWide</code> is not <code>true</code>, the user agent stores explicit lists and the call includes
+          one, then the database is checked for the existence of all the
           duplets (one per target):
         </p>
-        <pre>[*.domain, target]</pre>
+          <pre>[Domain, target domain]</pre>
+          <p>
+              Any processing failure, such as an incorrectly formatted parameter in the <a>ConfirmExceptionPropertyBag</a>,
+              will result in no duplet being removed from the data base of remebered grants, and
+              the returned <code>Promise</code> being
+              rejected with a <code>DOMException.SYNTAX_ERR</code>.
+          </p>
         <p>
-          If the user agent stores only site-wide exceptions or the call did
-          not include an explicit list, and the <code>domain</code> argument
-          is provided and is not empty then the database is checked for the
-          single duplet:
-        </p>
-        <pre>[*.domain, * ]</pre>
-        <p>
-          The returned <code>Promise</code> resolves to a
-          <code>ConfirmExceptionResult</code> object whose
-          <code>boolean</code> property <code><dfn>exists</dfn></code> has
+          Otherwise the returned <code>Promise</code> resolves to a
+          <code>ExceptionResult</code> object which MUST contain a
+          <code>boolean</code> property <code><dfn>exists</dfn></code> with
           the following possible values:
         </p>
         <ul>
@@ -2208,113 +2259,6 @@ object {
       </section>
     </section>
 
-    <section id="exception-ww-javascript-api">
-      <h3>Web-wide Exceptions</h3>
-
-      <section id="exception-javascript-api-ww-rqst">
-        <h4>API to Request a Web-wide Exception</h4>
-
-        <p>
-          <code><dfn>Navigator.storeWebWideTrackingException</dfn></code>
-          is called by a page to request the addition of a web-wide grant for a
-          specific site to the database.
-        </p>
-        <pre class="idl overlarge">
-        partial interface Navigator {
-            Promise&lt;void&gt; storeWebWideTrackingException (
-                            StoreExceptionPropertyBag properties
-                          );
-        };
-        </pre>
-        <p>
-          <a>Navigator.storeWebWideTrackingException</a> passes a
-          <a>StoreExceptionPropertyBag</a>, as described in
-          <a href="#exception-javascript-api-rqst" class="sectionRef"></a>.
-        </p>
-        <p>
-          The single duplet
-          <code>[ * , script domain]</code> or
-          <code>[ * , *.domain]</code> (based on if <code>domain</code>
-          is provided and is not null and not empty)
-          is added to the database of remembered grants.
-        </p>
-      </section>
-
-      <section id="exception-javascript-api-ww-cancel">
-        <h4>API to Cancel a Web-wide Exception</h4>
-
-        <p>
-          <code><dfn>Navigator.removeWebWideTrackingException</dfn></code>
-          is called by a page to request the removal of a web-wide grant for a
-          specific site from the database.
-        </p>
-        <pre class="idl overlarge">
-        partial interface Navigator {
-            Promise&lt;void&gt; removeWebWideTrackingException (
-                            RemoveExceptionPropertyBag properties
-                          );
-        };
-        </pre>
-        <p>
-          <a>Navigator.removeWebWideTrackingException</a> passes a
-          <a>RemoveExceptionPropertyBag</a>, as described in
-          <a href="#exception-javascript-api-cancel" class="sectionRef"></a>.
-        </p>
-        <p>
-          Ensures that the database of remembered grants no longer
-          contains the duplet <code>[ * , script domain]</code>
-          or <code>[ * , *.domain]</code> (based on if <code>domain</code>
-          is provided and is not null and not empty).
-        </p>
-        <p>
-          A <code>Promise</code> resolving to <code>void</code> is returned.
-          When the <code>Promise</code> is resolved, the
-          indicated pair is assured not to be in the database. The same
-          matching process defined for determining which header field to
-          send is also used to detect which entry (if any) to remove from
-          the database.
-        </p>
-      </section>
-
-      <section id="exception-javascript-api-ww-confirm">
-        <h4>API to Confirm a Web-wide Exception</h4>
-
-        <p>
-          <code><dfn>Navigator.confirmWebWideTrackingException</dfn></code>
-          is called by a page to confirm that there exists in the database a
-          web-wide exception for a specific site.
-        </p>
-        <pre class="idl overlarge">
-        partial interface Navigator {
-          Promise&lt;ConfirmExceptionResult&gt; confirmWebWideTrackingException (
-            ConfirmSiteSpecificExceptionPropertyBag properties
-          );
-        };
-        dictionary ConfirmExceptionResult {
-          boolean exists;
-        };
-        </pre>
-        <p>
-          <a>Navigator.confirmWebWideTrackingException</a> passes a
-          <a>ConfirmExceptionPropertyBag</a>, as described in
-          <a href="#exception-javascript-api-confirm" class="sectionRef"></a>.
-        </p>
-        <p>
-          The returned <code>Promise</code> resolves to a
-          <code>TrackingExceptionResult</code> object with a
-          <code>boolean</code> property <code>exists</code> indicating
-          whether the duplet <code>[ * , script domain]</code> or
-          <code>[ *, *.domain]</code> (based on if <code>domain</code> is
-          provided and is not null and not empty) exists in the database.
-        </p>
-        <ul>
-          <li><code>true</code> indicates that the web-wide exception
-            exists;</li>
-          <li><code>false</code> indicates that the web-wide exception
-            does not exist.</li>
-        </ul>
-      </section>
-    </section> 
     <section id="exception-no-js" class="informative">
       <h3>Exceptions without Interactive JavaScript</h3>
 


### PR DESCRIPTION
Now there are only 3 API functions, storeTrackingException, removeTrackingException and confirmTrackingException, with a new property in the propertybags determining if the call is web-wide or site-specific.
All calls now reject rather than throwing an exception. It uses DOMException.SYNTAX_ERR for wrong parameters and DOMException.SECURITY_ERR for cookie domain errors.