### PR TITLE
TPE compromise version

### DIFF
--- a/drafts/tracking-dnt-compromise.html
+++ b/drafts/tracking-dnt-compromise.html
@@ -1,0 +1,2585 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+<head>
+  <title>Tracking Preference Expression (DNT)</title>
+  <meta http-equiv='Content-Type' content='text/html;charset=utf-8'>
+  <script src='https://www.w3.org/Tools/respec/respec-w3c-common' class='remove' async></script>
+  <script class='remove'>
+    var respecConfig = {
+      specStatus:          "ED",
+      shortName:           "tracking-dnt",
+      // publishDate:         "2017-03-13",
+      previousPublishDate: "2015-08-20",
+      previousMaturity:    "CR",
+      edDraftURI:          "https://w3c.github.io/dnt/drafts/tracking-dnt.html",
+      prevED : "https://www.w3.org/2011/tracking-protection/drafts/tracking-dnt.html",
+      editors:  [
+          { name: "Roy T. Fielding", url: "http://roy.gbiv.com/",
+            company: "Adobe", companyURL: "https://www.adobe.com/",
+            w3cid: 31828 },
+          { name: "David Singer",
+            company: "Apple", companyURL: "https://www.apple.com/",
+            w3cid: 11534 }
+      ],
+      wg:          "Tracking Protection Working Group",
+      wgURI:       "https://www.w3.org/2011/tracking-protection/",
+      wgPublicList: "public-tracking",
+      wgPatentURI: "https://www.w3.org/2004/01/pp-impl/49311/status",
+   // issueBase:   "https://www.w3.org/2011/tracking-protection/track/issues/",
+      issueBase:   "https://github.com/w3c/dnt/issues",
+      githubAPI:   "https://api.github.com/repos/w3c/dnt",
+      processVersion: 2017,
+      otherLinks: [{
+                  key: 'Repository and Participation',
+                  data: [
+                      {
+                          value: 'Mailing list archive',
+                          href: 'https://lists.w3.org/Archives/Public/public-tracking/'
+                      }, {
+                          value: 'Commit history',
+                          href: 'https://github.com/w3c/dnt/commits'
+                      }, {
+                          value: 'File a bug/issue',
+                          href: 'https://github.com/w3c/dnt/issues'
+                      }
+                   ]
+                }],
+      localBiblio: {
+        "TCS": {
+          "authors": ["Nick Doty","Heather West","Justin Brookman","Sean Harvey","Erica Newland"],
+          "status" : "WD",
+          "href"   : "https://www.w3.org/TR/tracking-compliance/",
+       // "status" : "ED",
+       // "href"   : "https://www.w3.org/2011/tracking-protection/drafts/tracking-compliance.html",
+          "title"  : "Tracking Compliance and Scope",
+          "date"   : "31 March 2015",
+          "publisher" : "W3C"
+        },
+        "KnowPrivacy": {
+          "authors": ["Joshua Gomez","Travis Pinnick","Ashkan Soltani"],
+          "href"   : "http://www.knowprivacy.org/report/KnowPrivacy_Final_Report.pdf",
+          "title"  : "KnowPrivacy",
+          "date"   : "01 June 2009",
+          "publisher": "UC Berkeley, School of Information"
+        },
+        "Orderly": {
+          "authors": ["Lloyd Hilaiel"],
+          "href"   : "https://github.com/lloyd/orderly",
+          "title"  : "Orderly JSON",
+          "date"   : "22 February 2010"
+        },
+       "PromiseGuide":
+        {
+          "title": "Writing Promise-Using Specifications",
+          "href": "http://www.w3.org/2001/tag/doc/promises-guide",
+          "authors": [
+            "Domenic Denicola"
+          ],
+          "status": "Finding of the W3C TAG",
+          "publisher": "W3C",
+          "date"   : "03 January 2017"
+        }
+      },
+      noIDLSectionTitle: true,
+      noLegacyStyle: true
+    };
+  </script>
+  <style type="text/css">
+    p, li, dd {
+      hyphens: none;
+    }
+    table {
+      border-collapse: collapse;
+      border-style: hidden hidden none;
+    }
+    table thead {
+      border-bottom: medium solid;
+    }
+    table td, table th {
+      border-bottom: thin solid;
+      border-left: medium solid;
+      border-right: medium solid;
+      padding: 0.2em;
+      vertical-align: top;
+    }
+    table.simple {
+        margin-left: auto;
+        margin-right: auto;
+        width: 80%;
+    }
+    .simple tr {
+        vertical-align: top;
+    }
+    .example .example .example-title {
+        display: none
+    }
+    .option {
+        margin: 1em 0em 0em;
+        padding:    1em;
+        border: 2px solid #E2E3FF;
+        background: #F0F0FC;
+    }
+    .option::before {
+        content:    "Option";
+        display:    block;
+        width:  150px;
+        margin: -1.5em 0 0.5em 0;
+        font-weight:    bold;
+        border: 1px solid #8084FF;
+        background: #fff;
+        padding:    3px 1em;
+    }
+  </style>
+</head>
+<body>
+  <section id='abstract'>
+    <p>
+      This specification defines the <a>DNT</a> request header field as an
+      HTTP mechanism for expressing a user's preference regarding tracking,
+      an HTML DOM property to make that expression readable by scripts, and
+      APIs that allow scripts to register exceptions granted by
+      the user. It also defines mechanisms for sites to communicate whether
+      and how they honor a received preference, including
+      well-known resources for retrieving preflight tracking status,
+      a media type for representing tracking status information, and the
+      <q>Tk</q> response header field for confirming tracking status.
+    </p>
+  </section>
+
+  <section id='sotd'>
+    <p>
+      This document is an editors' straw man reflecting a snapshot of live
+      discussions within the
+      <a href="https://www.w3.org/2011/tracking-protection/">Tracking
+      Protection Working Group</a>.  It does not necessarily constitute
+      working group consensus.
+      This draft has been prepared using the
+      <a href="https://github.com/w3c/dnt/">DNT github repository</a> and its
+      associated <a href="https://github.com/w3c/dnt/issues">issues list</a>.
+      However, see the previous
+      <a href="https://www.w3.org/2011/tracking-protection/track/issues/">issue
+      tracking system</a> for working group decisions prior to 2017.
+    </p>
+  </section>
+
+  <section>
+    <h2>Introduction</h2>
+
+    <p>
+      The World Wide Web consists of billions of resources interconnected
+      through the use of hypertext. Hypertext provides a simple, page-oriented
+      view of the information provided by those resources, which can be
+      traversed by selecting links, manipulating controls, and supplying data
+      via forms and search dialogs.
+    </p>
+    <p>
+      A Web page is often composed of many information sources beyond the
+      initial resource request, including embedded references to stylesheets,
+      inline images, javascript, and other elements that might be
+      automatically requested as part of the rendering or behavioral
+      processing defined for that page. The user's experience is seamless,
+      even if the page has been composed from the results of many network
+      interactions with multiple servers. From the user's perspective, they
+      are simply visiting and interacting with a single Web site: all of the
+      technical details and protocol mechanisms used to compose a page to
+      represent that site are hidden behind the scenes.
+    </p>
+    <p>
+      Web site owners often collect data regarding usage of their sites, for a
+      variety of purposes, including what led a user to visit the site
+      (<dfn>referrals</dfn>), how effective the user experience is within the
+      site (<dfn>web analytics</dfn>), and the nature of who is using the
+      site (<dfn>audience segmentation</dfn>).
+      In some cases, the data collected is used to dynamically adapt content
+      (<dfn>personalization</dfn>) or advertising presented to the user
+      (<dfn>targeted advertising</dfn>). Data collection often occurs through
+      insertion of embedded elements on each page, resulting in a stream of
+      data that connects a user's activity across multiple pages. A survey of
+      these techniques and their privacy implications can be found in
+      [[KnowPrivacy]].
+    </p>
+    <p>
+      Users need a mechanism to express their own preferences regarding
+      <a>tracking</a> that is both simple to configure and efficient when
+      implemented. However, merely expressing a preference does not imply that
+      all recipients will comply. In some cases, a server might be dependent
+      on some forms of tracking and unwilling or unable to turn that off.
+      In other cases, a server might perform only limited forms of tracking
+      that would be acceptable to most users. Therefore, servers need
+      mechanisms for communicating their own tracking behavior, requesting
+      consent, and storing a <a>user-granted exception</a> once the user has
+      made an informed choice.
+    </p>
+    <p>
+      This specification extends Hypertext Transfer Protocol (HTTP) semantics
+      [[!RFC7231]] to communicate a user's tracking preference, if any, and an
+      origin server's tracking behavior. The <a>DNT</a> request header field
+      is defined for communicating the user's tracking preference for the
+      <a>target resource</a>. A well-known URI for a
+      <a href="#status-resource">tracking status resource</a> and the
+      <a>Tk</a> response header field are defined for communicating the
+      server's tracking behavior. In addition, JavaScript APIs are defined for
+      enabling scripts to determine DNT status and register a user-granted
+      exception.
+    </p>
+    <p>
+      This specification does not define requirements on what a recipient
+      needs to do to comply with a user's expressed tracking preference,
+      except for the means by which such compliance is communicated. Instead,
+      the tracking status provides the ability to identify a set of compliance
+      regimes to which the server claims to comply, with the assumption being
+      that each regime defines its own requirements on compliant behavior.
+      For example, [[TCS]] is a work-in-progress that intends to define such a
+      compliance regime.
+    </p>
+  </section>
+
+  <section id='terminology'>
+    <h2>Terminology</h2>
+
+    <section id='terminology.http'>
+      <h3>HTTP</h3>
+      <p>
+        The following terms are used as defined by HTTP/1.1 syntax [[!RFC7230]]
+        and semantics [[!RFC7231]]:
+        <dfn><a class="externalDFN" href="https://tools.ietf.org/html/rfc7230#section-2.1">client</a></dfn>,
+        <dfn><a class="externalDFN" href="https://tools.ietf.org/html/rfc7230#section-2.1">server</a></dfn>,
+        <dfn><a class="externalDFN" href="https://tools.ietf.org/html/rfc7230#section-2.1">origin server</a></dfn>,
+        <dfn><a class="externalDFN" href="https://tools.ietf.org/html/rfc7230#section-2.1">user agent</a></dfn>,
+        <dfn><a class="externalDFN" href="https://tools.ietf.org/html/rfc7230#section-2.1">sender</a></dfn>,
+        <dfn><a class="externalDFN" href="https://tools.ietf.org/html/rfc7230#section-2.1">recipient</a></dfn>,
+        <dfn><a class="externalDFN" href="https://tools.ietf.org/html/rfc7230#section-2.1">request</a></dfn>,
+        <dfn><a class="externalDFN" href="https://tools.ietf.org/html/rfc7230#section-2.1">response</a></dfn>,
+        <dfn><a class="externalDFN" href="https://tools.ietf.org/html/rfc7230#section-2.1">message</a></dfn>,
+        <dfn><a class="externalDFN" href="https://tools.ietf.org/html/rfc7230#section-2.3">intermediary</a></dfn>,
+        <dfn><a class="externalDFN" href="https://tools.ietf.org/html/rfc7230#section-2.3">proxy</a></dfn>,
+        <dfn><a class="externalDFN" href="https://tools.ietf.org/html/rfc7230#section-2.3">cache</a></dfn>,
+        <dfn><a class="externalDFN" href="https://tools.ietf.org/html/rfc7230#section-2.7">uri-host</a></dfn>,
+        <dfn><a class="externalDFN" href="https://tools.ietf.org/html/rfc7230#section-2.7">authority</a></dfn>,
+        <dfn><a class="externalDFN" href="https://tools.ietf.org/html/rfc7230#section-3.2">header field</a></dfn>,
+        <dfn><a class="externalDFN" href="https://tools.ietf.org/html/rfc7230#section-5.1">target resource</a></dfn>,
+        <dfn><a class="externalDFN" href="https://tools.ietf.org/html/rfc7231#section-2">resource</a></dfn>, and
+        <dfn><a class="externalDFN" href="https://tools.ietf.org/html/rfc7231#section-3">representation</a></dfn>.
+      </p>
+    </section>
+
+    <section id='terminology.html'>
+      <h3>HTML</h3>
+      <p>
+        The following terms are used as defined by HTML [[!HTML5]]:
+        <dfn><a class="externalDFN" href="https://www.w3.org/TR/html5/single-page.html#active-document">active document</a></dfn>,
+        <dfn><a class="externalDFN" href="https://www.w3.org/TR/html5/single-page.html#dom-document-domain">document.domain</a></dfn>,
+        <dfn><a class="externalDFN" href="https://www.w3.org/TR/html5/single-page.html#effective-script-origin">effective script origin</a></dfn>,
+        <dfn><a class="externalDFN" href="https://www.w3.org/TR/html5/single-page.html#responsible-document">responsible document</a></dfn>,
+        <dfn><a class="externalDFN" href="https://www.w3.org/TR/html5/single-page.html#browsing-context">browsing context</a></dfn>,
+        <dfn><a class="externalDFN" href="https://www.w3.org/TR/html5/single-page.html#nested-browsing-context">nested browsing context</a></dfn>, and
+        <dfn><a class="externalDFN" href="https://www.w3.org/TR/html5/single-page.html#top-level-browsing-context">top-level browsing context</a></dfn>.
+      </p>
+    </section>
+
+    <section id='terminology.activity'>
+      <h3>Activity</h3>
+
+      <p>
+        <dfn>Tracking</dfn> is the collection of data regarding a particular
+        user's activity across multiple distinct contexts and the retention,
+        use, or sharing of data derived from that activity outside the
+        context in which it occurred.
+        A <dfn>context</dfn> is a set of resources that are controlled by
+        the same party or jointly controlled by a set of parties.
+      </p>
+      <p>
+        A <dfn>network interaction</dfn> is a single HTTP request and its
+        corresponding response(s): zero or more interim (1xx) responses and
+        a single final (2xx-5xx) response.
+      </p>
+      <p>
+        A <dfn>user action</dfn> is a deliberate action by the user, via
+        configuration, invocation, or selection, to initiate a network
+        interaction. Selection of a link, submission of a form, and
+        reloading a page are examples of user actions.
+        <dfn>User activity</dfn> is any set of such user actions.
+      </p>
+    </section>
+
+    <section id='terminology.participants'>
+      <h3>Participants</h3>
+
+      <p>
+        A <dfn>user</dfn> is a natural person who is making, or has made,
+        use of the Web.
+      </p>
+      <p>
+        A <dfn>party</dfn> is a natural person, a legal entity, or a set of
+        legal entities that share common owner(s), common controller(s), and
+        a group identity that is easily discoverable by a user. Common
+        branding or providing a list of affiliates that is available via a
+        link from a resource where a party describes DNT practices are
+        examples of ways to provide this discoverability.
+      </p>
+      <p>
+        With respect to a given user action, a <dfn>first party</dfn>
+        is a party with which the user intends to interact, via one or more
+        network interactions, as a result of making that action. Merely
+        hovering over, muting, pausing, or closing a given piece of content
+        does not constitute a user's intent to interact with another party.
+      </p>
+      <p>
+        In some cases, a resource on the Web will be jointly controlled by
+        two or more distinct parties. Each of those parties is considered a
+        first party if a user would reasonably expect to communicate with
+        all of them when accessing that resource. For example, prominent
+        co-branding on the resource might lead a user to expect that
+        multiple parties are responsible for the content or functionality.
+      </p>
+      <p>
+        For any data collected as a result of one or more network
+        interactions resulting from a user's action,
+        a <dfn>third party</dfn> is any party other than that user, a first
+        party for that user action, or a service provider acting on behalf
+        of either that user or that first party.
+      </p>
+      <p>
+        Access to Web resources often involves multiple parties that might
+        process the data received in a network interaction. For example,
+        domain name services, network access points, content distribution
+        networks, load balancing services, security filters, cloud
+        platforms, and software-as-a-service providers might be a party to a
+        given network interaction because they are contracted by either the
+        user or the resource owner to provide the mechanisms for
+        communication. Likewise, additional parties might be engaged after a
+        network interaction, such as when services or contractors are used
+        to perform specialized data analysis or records retention.
+      </p>
+      <p>
+        For the data received in a given network interaction, a
+        <dfn>service provider</dfn> is considered to be the same party as
+        its <dfn>contractee</dfn> if the service provider:
+      </p>
+      <ol>
+        <li>processes the data on behalf of the contractee;</li>
+        <li>ensures that the data is only retained, accessed, and used as
+            directed by the contractee;</li>
+        <li>has no independent right to use the data other than in a
+            <a>permanently de-identified</a> form (e.g., for monitoring
+            service integrity, load balancing, capacity planning, or
+            billing); and,</li>
+        <li>has a contract in place with the contractee which is consistent
+            with the above limitations.</li>
+      </ol>
+    </section>
+
+    <section id='terminology.data'>
+      <h3>Data</h3>
+
+      <p>
+        A party <dfn>collects</dfn> data received in a network interaction
+        if that data remains within the party’s control after the network
+        interaction is complete.
+      </p>
+      <p>
+        A party <dfn>uses</dfn> data if the party processes the data for any
+        purpose other than storage or merely forwarding it to another party.
+      </p>
+      <p>
+        A party <dfn>shares</dfn> data if it transfers or provides a copy of
+        that data to any other party.
+      </p>
+      <p>
+        Data is <dfn>permanently de-identified</dfn> when there exists a
+        high level of confidence that no human subject of the data can be
+        identified, directly or indirectly (e.g., via association with an
+        identifier, user agent, or device), by that data alone or in
+        combination with other retained or available information.
+      </p>
+    </section>
+  </section>
+
+  <section id='notational'>
+    <h2>Notational Conventions</h2>
+
+    <section id='requirements'>
+      <h3>Requirements</h3>
+
+      <p>The key words <em title="must" class="rfc2119">must</em>,
+        <em title="must not" class="rfc2119">must not</em>,
+        <em title="required" class="rfc2119">required</em>,
+        <em title="should" class="rfc2119">should</em>,
+        <em title="should not" class="rfc2119">should not</em>,
+        <em title="recommended" class="rfc2119">recommended</em>,
+        <em title="may" class="rfc2119">may</em>, and
+        <em title="optional" class="rfc2119">optional</em> in this
+        specification are to be interpreted as described in [[!RFC2119]].
+      </p>
+    </section>
+
+    <section id='notation'>
+      <h3>Formal Syntax</h3>
+
+      <p>
+        This specification uses the Augmented Backus-Naur Form (ABNF)
+        notation of [[!RFC5234]] to define network protocol syntax and
+        WebIDL [[!WEBIDL]] to define scripting APIs.
+        Conformance criteria and considerations regarding error handling are
+        defined in Section 2.5 of [RFC7230].
+      </p>
+      <p>
+        How to <dfn><a class="externalDFN" href="https://heycam.github.io/webidl/#dfn-throw">throw</a></dfn>
+        a <dfn><a class="externalDFN" href="https://heycam.github.io/webidl/#idl-DOMException">DOMexception</a></dfn>
+        and the <dfn><a class="externalDFN" href="https://heycam.github.io/webidl/#idl-exceptions">exceptions</a></dfn>
+        named "InvalidStateError", "SecurityError", and "SyntaxError" are
+        defined in [[!WEBIDL]].
+      </p>
+      <p>
+        <dfn><a class="externalDFN" href="https://tc39.github.io/ecma262/#sec-promise-objects">Promise objects</a></dfn>
+        are defined in [[ECMASCRIPT]]; the phrases
+        <dfn><a class="externalDFN" href="https://www.w3.org/2001/tag/doc/promises-guide#promise-call">promise-call</a></dfn>,
+        <dfn><a class="externalDFN" href="https://www.w3.org/2001/tag/doc/promises-guide#resolve-promise">resolve promise</a></dfn>,
+        <dfn><a class="externalDFN" href="https://www.w3.org/2001/tag/doc/promises-guide#reject-promise">reject promise</a></dfn>,
+        <dfn><a class="externalDFN" href="https://www.w3.org/2001/tag/doc/promises-guide#upon-fulfillment">upon fulfillment</a></dfn>, and
+        <dfn><a class="externalDFN" href="https://www.w3.org/2001/tag/doc/promises-guide#upon-rejection">upon rejection</a></dfn>
+        are used in accordance with [[PromiseGuide]].
+      </p>
+    </section>
+  </section>
+
+  <section id='determining'>
+    <h2>Determining User Preference</h2>
+
+    <p>
+      The goal of this protocol is to allow a user to express their
+      personal preference regarding tracking to each server and
+      web application that they communicate with via HTTP, thereby allowing
+      recipients of that preference to adjust tracking behavior accordingly
+      or to reach a separate agreement with the user that satisfies all
+      parties.
+    </p>
+    <p>
+      Key to that notion of expression is that the signal sent MUST reflect
+      the user's preference, not the choice of some vendor, institution,
+      site, or network-imposed mechanism outside the user's control;
+      this applies equally to both the general preference and exceptions.
+      The basic principle is that a tracking preference expression is only
+      transmitted when it reflects a deliberate choice by the user. In the
+      absence of user choice, there is no tracking preference expressed
+      (see <a href="#privacy.not-preconfigured" class="sectionRef"></a>).
+    </p>
+    <p>
+      A user agent MUST offer users a minimum of two alternative choices
+      for a <q>Do Not Track</q> preference: <code><dfn>unset</dfn></code> or
+      <code><dfn>DNT:1</dfn></code>.
+      A user agent MAY offer a third alternative choice: <code><dfn>DNT:0</dfn></code>.
+    </p>
+    <p>
+      If the user's choice is <a>DNT:1</a> or <a>DNT:0</a>, the
+      tracking preference is <dfn>enabled</dfn>; otherwise, the
+      tracking preference is <dfn>not enabled</dfn>.
+    </p>
+    <p>
+      A user agent MUST have a default tracking preference of
+      <code>unset</code> (not enabled) unless a specific tracking preference
+      is implied by the user's decision to use that agent. For example, use
+      of a general-purpose browser would not imply a tracking preference
+      when invoked normally as <q>SuperFred</q>, but might imply a
+      preference if invoked as <q>SuperDoNotTrack</q> or
+      <q>UltraPrivacyFred</q>.
+    </p>
+    <p>
+      Implementations of HTTP that are not under control of the user
+      MUST NOT add, delete, or modify a tracking preference.
+      Some controlled network environments, such as public access
+      terminals or managed corporate intranets, might impose restrictions
+      on the use or configuration of installed user agents, such that a
+      user might only have access to user agents with a predetermined
+      preference enabled.  However, if a user brings their
+      own Web-enabled device to a library or cafe with wireless Internet
+      access, the expectation will be that their chosen user agent and
+      personal preferences regarding Web site behavior will not be
+      altered by the network environment (aside from blanket limitations
+      on what resources can or cannot be accessed through that network).
+    </p>
+    <p>
+      An HTTP intermediary MUST NOT add, delete, or modify a tracking
+      preference expression in a request forwarded through that intermediary
+      unless the intermediary has been specifically installed or configured
+      to do so by the user making the request. For example, an Internet
+      Service Provider MUST NOT inject <a>DNT:1</a> on behalf
+      of all users who have not expressed a preference.
+    </p>
+    <p>
+      User agents often include user-installable <dfn>extensions</dfn>, also
+      known as <dfn>add-ons</dfn> or <dfn>plug-ins</dfn>, that are
+      capable of modifying configurations and making network requests. From
+      the user's perspective, these extensions are considered part of the
+      user agent and ought to respect the user's configuration of a tracking
+      preference. The user agent as a whole is responsible for ensuring
+      conformance with this protocol, to the extent possible, which means
+      the user agent core and each extension are jointly responsible for
+      conformance. However, there is no single standard for extension
+      interfaces. A user agent that permits such extensions SHOULD provide
+      an appropriate mechanism for extensions to determine the user's
+      tracking preference.
+    </p>
+    <p>
+      A user agent extension MUST NOT alter the tracking preference
+      expression or its associated configuration unless the act of
+      installing and enabling that extension is an explicit choice by the
+      user for that tracking preference, or the extension itself complies
+      with all of the requirements this protocol places on a user agent.
+    </p>
+    <p>
+      Likewise, software outside of the user agent might filter network
+      traffic or cause a user agent's configuration to be changed.
+      Software that alters a user agent configuration MUST adhere to the
+      above requirements on a user agent extension. Software that filters
+      network traffic MUST adhere to the above requirements on an HTTP
+      intermediary.
+    </p>
+    <p>
+      Aside from the above requirements, we do not specify how the tracking
+      preference choices are offered to the user or how the preference is
+      enabled: each implementation is responsible for determining the user
+      experience by which a tracking preference is <a>enabled</a>.
+    </p>
+    <p>
+      For example, a user might select a check-box in their user agent's
+      configuration, install an extension that is specifically
+      designed to add a tracking preference expression,
+      or make a choice for privacy that then implicitly includes a
+      tracking preference (e.g., <q>Privacy settings: high</q>).
+      A user agent might ask the user for their preference during startup,
+      perhaps on first use or after an update adds the tracking protection
+      feature. Likewise, a user might install or configure a proxy to add
+      the expression to their own outgoing requests.
+    </p>
+  </section>
+
+  <section id='expressing'>
+    <h2>Expressing a Tracking Preference</h2>
+
+    <section id='expression-format'>
+      <h3>Expression Format</h3>
+      <p>
+        When a user has <a>enabled</a> a tracking preference, that
+        preference needs to be expressed to all mechanisms that might
+        perform or initiate <a>tracking</a>.
+      </p>
+      <p>
+        When <a>enabled</a>, a tracking preference is expressed as either:
+      </p>
+      <table class="simple">
+        <tr><th>DNT</th>
+            <th>meaning</th>
+        </tr>
+        <tr><td>1</td>
+            <td>This user prefers not to be tracked on this request.</td>
+        </tr>
+        <tr><td>0</td>
+            <td>This user prefers to allow tracking on this request.</td>
+        </tr>
+      </table>
+      <p>
+        A user agent MUST NOT send a tracking preference expression if
+        a tracking preference is <a>not enabled</a>.  This means that no
+        expression is sent for each of the following cases:
+      </p>
+      <ul>
+        <li>the user agent does not implement this protocol;</li>
+        <li>the user has not yet made a choice for a specific preference;
+            or,</li>
+        <li>the user has chosen not to transmit a preference.</li>
+      </ul>
+      <p>
+        In the absence of regulatory, legal, or other requirements, servers
+        MAY interpret the lack of an expressed tracking preference as they
+        find most appropriate for the given user, particularly when
+        considered in light of the user's privacy expectations and cultural
+        circumstances. Likewise, servers might make use of other preference
+        information outside the scope of this protocol, such as
+        site-specific user preferences or third-party registration services,
+        to inform or adjust their behavior when no explicit preference is
+        expressed via this protocol.
+      </p>
+    </section>
+
+    <section id='dnt-header-field'>
+      <h3>DNT Header Field for HTTP Requests</h3>
+
+      <p>
+        The <code><dfn>DNT</dfn></code> header field is a mechanism for expressing the
+        user's tracking preference in an HTTP request ([[!RFC7230]]).
+        At most one <code>DNT</code> header field can be present in a valid request.
+      </p>
+<pre class="abnf">
+DNT-field-name  = "DNT"
+DNT-field-value = ( "0" / "1" ) *DNT-extension
+</pre>
+      <p>
+        A user agent MUST NOT generate a <code>DNT</code> header field if the
+        user's tracking preference is <a>not enabled</a>.
+      </p>
+      <p>
+        A user agent MUST generate a <code>DNT</code> header field with a
+        field-value that begins with the numeric character "1" if the user's
+        tracking preference is <a>enabled</a>, their preference is for
+        <a>DNT:1</a>, and no exception has been granted for the
+        target resource (see <a href="#exceptions" class="sectionRef"></a>).
+      </p>
+      <p>
+        A user agent MUST generate a <code>DNT</code> header field with a
+        field-value that begins with the numeric character "0" if the user's
+        tracking preference is <a>enabled</a> and their preference is for
+        <a>DNT:0</a>, or if an exception has been granted for
+        the target resource.
+      </p>
+      <p>
+        A proxy MUST NOT generate a <code>DNT</code> header field unless it has
+        been specifically installed or configured to do so by the user
+        making the request and adheres to the above requirements as if it
+        were a user agent.
+      </p>
+<pre class="example">
+GET /something/here HTTP/1.1
+Host: example.com
+DNT: 1
+
+</pre>
+
+      <section id='dnt-extensions'>
+        <h4>Extensions to the DNT Field Value</h4>
+
+        <p>
+          The remainder of the <a>DNT</a> field-value, after the initial character,
+          is reserved for future extensions. DNT extensions can only be
+          transmitted when a tracking preference is <a>enabled</a>.
+          The extension syntax is restricted to visible ASCII characters that
+          can be parsed as a single word in HTTP and safely embedded in a
+          JSON string without further encoding
+          (<a href="#status-representation" class="sectionRef"></a>).
+        </p>
+<pre class="abnf">
+DNT-extension   = %x21 / %x23-2B / %x2D-5B / %x5D-7E
+                ; excludes CTL, SP, DQUOTE, comma, backslash
+</pre>
+        <p>
+          For example, additional characters might indicate modifiers to the
+          main preference expressed by the first digit, such that the main
+          preference will be understood if the recipient does not understand
+          the extension. Hence, a field-value of "1xyz" can be thought of
+          as <q>do not track, but if you understand the refinements defined
+          by x, y, or z, then adjust my preferences according to those
+          refinements.</q>
+        </p>
+        <p>
+          User agents that do not implement DNT extensions MUST NOT send
+          DNT-extension characters in the <a>DNT</a> field-value.
+          Servers that do not implement DNT extensions SHOULD ignore
+          anything beyond the first character.
+        </p>
+        <p class="note">
+          This DNT-extension feature is speculative because no known
+          extensions have been defined; implementers that do not read this
+          specification are likely to assume that DNT only has the
+          fixed values of "0" or "1". Furthermore, the potential benefits
+          of this mechanism are unclear given that extension information
+          could be supplied using separate request header fields.
+          Inappropriate extensions to the "1" value might cause the user's
+          requests to be more easily
+          <a href="#privacy.fingerprinting">fingerprinted</a>.
+        </p>
+      </section>
+    </section>
+
+    <section id='js-dom'>
+      <h3>JavaScript Property to Detect Preference</h3>
+
+      <p>
+        The <code><dfn>Navigator.doNotTrack</dfn></code> property enables
+        a client-side script with read access to the
+        <code><dfn data-cite="!HTML5#navigator">Navigator</dfn></code> object
+        [[!HTML5]] to determine what <a>DNT</a> header field value would be
+        sent to the <a>effective script origin</a>, taking into account the
+        user's general preference (if any) and user-granted exceptions
+        applicable to the <a>target domain</a> when referenced by the
+        active document's <a>top-level browsing context</a>.
+      </p>
+      <pre class="idl">
+        partial interface Navigator {
+            readonly attribute DOMString? doNotTrack;
+        };
+      </pre>
+      <p>
+        The value is <code>null</code> if no DNT header field would be
+        sent (e.g., because a tracking preference is <a>not enabled</a>
+        and no user-granted exception is applicable);
+        otherwise, the value is a string beginning with "0" or "1",
+        possibly followed by DNT-extension characters.
+      </p>
+      <p>
+        Specifically, the value of <a>Navigator.doNotTrack</a> for a given
+        script is either <code>null</code> or the string value that would be
+        sent in a <a>DNT</a> field-value
+        (<a href="#dnt-header-field" class="sectionRef"></a>)
+        in a request to a <a>target resource</a> at the
+        <a>effective script origin</a> (the current <a>document.domain</a> of
+        the script's <a>responsible document</a>) when that request is due to
+        an embedded reference from this site (the <a>document.domain</a> of
+        the <a>top-level browsing context</a>'s <a>active document</a>).
+      </p>
+      <p>
+        Ideally, the value of <a>Navigator.doNotTrack</a> ought to reflect
+        the current set of user-granted exceptions in effect when the
+        attribute is read. In practice, however, the value might only reflect
+        the value that was in effect when the script was initiated.
+      </p>
+    </section>
+
+    <section id='other-protocols'>
+      <h3>Tracking Preference Expressed in Other Protocols</h3>
+
+      <p>
+        A user's tracking preference is intended to apply in general,
+        regardless of the protocols being used for Internet communication.
+        However, it is beyond the scope of this specification to define how
+        a user's tracking preference might be communicated via protocols
+        other than HTTP.
+      </p>
+    </section>
+  </section>
+
+  <section id='exceptions' >
+    <h2>User-Granted Exceptions</h2>
+
+    <section id="exception-overview">
+      <h3>Overview</h3>
+
+      <p>
+        Content providers might wish to prompt visitors to <q>opt in</q> to
+        tracking for behavioral advertising or similar purposes when they
+        arrive with the Do Not Track setting enabled. However, granting an
+        exception in one context (e.g., while browsing a news site) does not
+        imply that exception is applicable to other contexts (e.g., browsing
+        an unrelated medical site). Furthermore, users might wish to view or
+        edit all the exceptions they've granted in a single, consistent user
+        interface, rather than managing preferences in a different way on
+        every content provider or tracker's privacy page.
+      </p>
+      <p>
+        A <dfn>user-granted exception</dfn> is the record of a decision by
+        the user to grant consent for tracking (<a>DNT:0</a>) on future
+        requests from a given site to a set of target domains.
+        Both site and target are scoped by domain, similar to the existing
+        domain scope of cookies
+        (<a href="https://www.w3.org/TR/html5/single-page.html#relaxing-the-same-origin-restriction">Section 5.3.1</a>
+        of [[!HTML5]]), to avoid prompting the user for every subdomain of a
+        site and every target resource that might be referenced.
+      </p>
+      <p>
+        A client-side database can be used for persistent storage of
+        user-granted exceptions, such that permission to send <a>DNT:0</a>
+        is obtained by a site and stored via a JavaScript API. However, we
+        only define the API (below); the choice of storage mechanism is left
+        to each implementation. In comparison to the use of cookies to manage
+        consent, an exception database and APIs provide more transparency and
+        better user control, while also providing better persistence of those
+        exceptions for sites.
+      </p>
+    </section>
+
+    <section id="exception-scope">
+      <h3>Site-specific or Web-wide</h3>
+
+      <p>
+        There are two primary domain concepts involved
+        in the processing of user-granted exceptions:
+      </p>
+      <dl>
+        <dt><dfn>site domain</dfn></dt>
+        <dd>the domain associated with a site on which a given reference
+          might be found and for which the user-granted
+          exceptions API might be queried: specifically, the current
+          <a>document.domain</a> of the <a>top-level browsing context</a>'s
+          <a>active document</a> [[!HTML5]].</dd>
+        <dt><dfn>target domain</dfn></dt>
+        <dd>the <a>uri-host</a> subcomponent of the <a>authority</a> component
+          of a referenced "http" or "https" URI [[!RFC7230]].</dd>
+      </dl>
+      <p>
+        A user-granted exception is <dfn>site-specific</dfn> if the exception
+        is limited to requests embedded in, or referred by, a given
+        <a>site domain</a>; otherwise, the exception is <dfn>web-wide</dfn>
+        because it applies to the target domain regardless of the referring
+        site. For example, a user might wish to grant a certain target domain
+        a web-wide exception for the purpose of audience measurement across
+        multiple sites, perhaps in exchange for some incentive.
+      </p>
+      <p>
+        When asking for consent to record a <a>site-specific</a> exception,
+        a site might make some claims regarding limitations on the actions and
+        behavior of the known third parties that it references. Such a site
+        might wish to restrict its <a>site-specific</a> exceptions to only
+        target domains for which those claims have been verified.
+        (For example, consider the dilemma of a site that has trusted
+        advertisers and analytics providers, along with some less trusted
+        mashed-up content that might reference other sites). For this reason,
+        <a>site-specific</a> exceptions can either be limited to a named set of
+        target domains or be applicable to any target domain ("*").
+      </p>
+    </section>
+
+    <section id='exception-granting'>
+      <h3>Granting an Exception</h3>
+
+      <p>
+        It is expected that a site will explain to the user, in its online
+        content, the need for an exception and the consequences of granting or
+        denying that exception. Upon receipt of an informed consent from the
+        user, a script operating on the site's page is expected to
+        promise-call the <a>Navigator.storeTrackingException</a> API using
+        parameters consistent with the consent granted by the user.
+      </p>
+      <p>
+        A site MUST ensure that a call to store an exception reflects the
+        user's intention to grant an exception at the time of that call. It
+        is the sole responsibility of the site to determine that a call to
+        record an exception reflects the user's informed consent at the
+        time of that call.
+      </p>
+      <p>
+        Third party target domains that might wish to receive a user-granted
+        exception often do not have the ability to invoke an interactive
+        JavaScript presence on a page (for example, those that provide only
+        images or "tracking pixels"). They cannot request an exception under
+        these circumstances, either because a script is needed to make the
+        API call or it requires interaction to ensure the user is informed
+        and to receive an indication of their consent. In general, this
+        process of informing, getting consent, and calling the API is not
+        expected within page elements where such trackers are invoked.
+      </p>
+      <p>
+        A first party site's page (the <a>top-level browsing context</a>)
+        might be used to obtain <a>site-specific</a> consent for multiple
+        parties;
+        e.g., using multiple iframe elements containing scripts that can
+        convey information about each party's policies and obtain specific
+        consent for each party. In this case, the <a>effective script origin</a>
+        might be different from the site for which consent is being granted.
+      </p>
+      <p>
+        Alternatively, a third party might encourage the user to visit their
+        own site directly in order to engage in a consent dialog and make use
+        of the API to store a <a>web-wide</a> exception.
+        A <a>web-wide</a> exception can only be stored via the API when
+        interacting with the web-wide target domain directly as a
+        <a>first party</a>.
+      </p>
+      <p>
+        A site can request an exception be stored even when the user's
+        general preference is <a>not enabled</a>. This permits the sending of
+        <a>DNT</a> only for target resources for which an expressed
+        preference is desired. Stored exceptions could affect which
+        preference is transmitted if a user later chooses to configure a
+        general tracking preference.
+      </p>
+      <p>
+        A user agent might not store the exception immediately, possibly
+        because it is allowing the user to confirm. Even though the site has
+        acquired the user's informed consent before calling the store API,
+        it is possible that the user will change their mind, allow the
+        storing of an exception to proceed but later remove it, or perhaps
+        deny the storage by prior configuration.
+        Nonetheless, at the time of a call, the site has acquired the
+        user's consent and can proceed on that basis whether or not the
+        user agent has stored an exception.
+      </p>
+    </section>
+
+    <section id='exception-checking'>
+      <h3>Checking for an Exception</h3>
+
+      <p>
+        A site can promise-call the <a>Navigator.trackingExceptionExists</a>
+        API to enquire whether an exception has been granted and stands in
+        the user agent. If it resolves to false (the exception has expired,
+        been deleted, or has not yet been stored), the user can be asked
+        again for consent.
+      </p>
+      <p>
+        A user agent is expected to query the exceptions database at the
+        time of a request in order to determine what value (if any) to send
+        as the user's tracking preference.
+      </p>
+      <ul>
+        <li>While the user is browsing a given site,
+          if the duplet [<a>site domain</a>, <a>target domain</a>] matches
+          any duplet in the database, then a <a>DNT:0</a> preference is sent,
+          otherwise the user’s general preference is sent (if any).</li>
+      </ul>
+      <p>
+        A pair of duplets [A,B] and [X,Y] match if A matches X and B matches Y.
+        A pair of values A and X match if and only if one of the following
+        is true:
+      </p>
+      <ul>
+        <li>either A or X is "*";</li>
+        <li>A and X are the same string;</li>
+        <li>A has the form '*.domain' and X is 'domain' or is of the form
+          'string.domain', where 'string' is any sequence of characters.</li>
+      </ul>
+      <p class="example">
+        For example, a user might grant an exception for metrics.example.net
+        to track their activity on news.example.com and weather.example.com,
+        but not on medical.example.org. If the document at
+        <code>http://news.example.com/news/story/2098373.html</code>
+        has embedded references to
+        <code>http://metrics.example.net/1x1.gif</code> and
+        <code>http://weather.example.com/widget.js</code>, the
+        site domain for those references is
+        <code>news.example.com</code> and the target domains are
+        <code>metrics.example.net</code> and
+        <code>weather.example.com</code>, respectively. 
+      </p>
+      <p>
+        A user agent MAY choose to disregard a user-granted exception when
+        the <a>target resource</a> does not have a corresponding tracking
+        status resource with a valid tracking status representation, since
+        that would imply the <a>target resource</a> does not conform to this
+        specification.
+      </p>
+    </section>
+
+    <section id='exception-revoking'>
+      <h3>Revoking an Exception</h3>
+
+      <p>
+        A site that stores exceptions is also expected to enable revocation
+        of those exceptions. The <a>Navigator.removeTrackingException</a> API
+        can be promise-called by a script to remove all exceptions applicable
+        to that site.
+      </p>
+      <p>
+        A site MAY monitor for changes to its user-granted exceptions.
+        If a user revokes consent by deleting an exception, the site MUST
+        respect that revocation, though it MAY ask again for a new
+        exception. In other words, a site MUST NOT resurrect a deleted
+        exception without first interacting with and receiving new 
+        consent from the user.
+      </p>
+    </section>
+
+    <section id="exception-javascript-api">
+      <h3>Client-side Scripting API</h3>
+
+        <section id="exception-javascript-api-store">
+            <h4>API to Store a Tracking Exception</h4>
+            <p>
+                When a site has obtained consent for a
+                <a>user-granted exception</a>, a script running within an active
+                <a>browsing context</a> or <a>nested browsing context</a> of that
+                site can <a>promise-call</a>
+                <code><dfn>Navigator.storeTrackingException</dfn></code>
+                to store one or more tracking exceptions.
+                A <code><dfn>TrackingExData</dfn></code> object is
+                supplied as a parameter to define the exception's scope (the set of
+                [site, target] duplets that encompass the granted exception)
+                and optional information to be stored for that exception.
+                The call returns a promise which either resolves to a
+                <code><dfn>TrackingExResult</dfn></code> or is rejected with
+                a <code>DOMException</code> identifying the reason for the failure.
+            </p>
+            <pre class="idl">
+        partial interface Navigator {
+            Promise&lt;TrackingExResult&gt; storeTrackingException (
+              TrackingExData properties
+            );
+        };
+        dictionary TrackingExData {
+           DOMString? site;
+           sequence&lt;DOMString&gt;? targets;
+           DOMString? name;
+           DOMString? explanation;
+           DOMString? details;
+           long?      maxAge;
+        };
+        dictionary TrackingExResult {
+          boolean isSiteWide;
+        };
+        </pre>
+            <p>
+                <a>Navigator.storeTrackingException</a> passes a
+                <a>TrackingExData</a> object. A user agent MUST ignore unknown
+                properties of the <a>TrackingExData</a> object (for future
+                extensibility). The following OPTIONAL properties are defined:
+            </p>
+            <dl data-dfn-for="TrackingExData">
+                <dt><code><dfn>site</dfn></code></dt>
+                <dd>
+                    The referring domain scope for which the exception applies:
+                    <ul>
+                        <li>
+                            If
+                            <a data-link-for="TrackingExData">site</a> is
+                            undefined, null, or the empty string, the exception's
+                            referring domain scope defaults to the
+                            <a>effective script origin</a>.
+                        </li>
+                        <li>
+                            If
+                            <a data-link-for="TrackingExData">site</a> is
+                            defined and equal to "<code>*</code>", the exception is
+                            intended to be <a>web-wide</a> for the set of
+                            <a data-link-for="TrackingExData">targets</a>.
+                            A user agent MUST reject the promise with the
+                            <code>DOMException</code> named "SecurityError" if both
+                            <a data-link-for="TrackingExData">site</a> and
+                            any of the <a data-link-for="TrackingExData">targets</a>
+                            are "<code>*</code>".
+                        </li>
+                        <li>
+                            Otherwise, the exception's referring domain scope is defined
+                            by a domain found
+                            in <a data-link-for="TrackingExData">site</a>
+                            that is treated in the same way as the domain parameter to
+                            cookies [[!RFC6265]], allowing subdomains to be included with
+                            the prefix "<code>*.</code>". The value
+                            can be set to a fully-qualified right-hand segment of the
+                            document host name, up to one level below TLD.
+                        </li>
+                    </ul>
+                </dd>
+                <dt><code><dfn>targets</dfn></code></dt>
+                <dd>
+                    An array of target domains for which the exception applies:
+                    <ul>
+                        <li>
+                            If <a data-link-for="TrackingExData">targets</a>
+                            is undefined, null, or an empty array, the user-granted
+                            exception to be stored is <code>[site,&nbsp;*]</code>, meaning
+                            that the exception applies to all domains referenced by the
+                            site.
+                        </li>
+                        <li>
+                            Otherwise, for each domain string in the
+                            <a data-link-for="TrackingExData">targets</a>
+                            array, the user-granted exception to be stored is the duplet
+                            <code>[site,&nbsp;domain]</code>.
+                        </li>
+                    </ul>
+                </dd>
+                <dt><code><dfn>name</dfn></code></dt>
+                <dd>
+                    When defined and not null or an empty string,
+                    <a data-link-for="TrackingExData">name</a> is a
+                    user-readable string for naming the exception, usually
+                    descriptive of the targets or their intended purpose for this
+                    site.
+                </dd>
+                <dt><code><dfn>explanation</dfn></code></dt>
+                <dd>
+                    When defined and not null or an empty string,
+                    <a data-link-for="TrackingExData">explanation</a> is a
+                    user-readable short explanation of the granted exception.
+                </dd>
+                <dt><code><dfn>details</dfn></code></dt>
+                <dd>
+                    When defined and not null or an empty string,
+                    <a data-link-for="TrackingExData">details</a> is a URI
+                    reference at which further information about the granted
+                    exception can be found [[!RFC3986]].
+                </dd>
+                <dt><code><dfn>maxAge</dfn></code></dt>
+                <dd>
+                    When defined and not null,
+                    <a data-link-for="TrackingExData">maxAge</a> is a positive
+                    number of seconds indicating the maximum lifetime of the grant:
+                    <ul>
+                        <li>
+                            If <code>maxAge</code> is supplied and not null, empty, or
+                            negative, the user agent MUST remove the stored exception
+                            no later than the specified number of seconds after being
+                            stored.
+                        </li>
+                        <li>
+                            If <code>maxAge</code> is not supplied, the user agent
+                            MAY retain the stored grant indefinitely.
+                        </li>
+                    </ul>
+                </dd>
+            </dl>
+            <p>
+                The properties <a data-link-for="TrackingExData">name</a>,
+                <a data-link-for="TrackingExData">explanation</a>, and
+                <a data-link-for="TrackingExData">details</a> are provided by the
+                caller for the sake of potential user interfaces.
+                If a user agent presents these properties to the user, it ought to
+                be clear that they are provided for informational value and are
+                less important than the exception's technical effect.
+            </p>
+            <p>
+                In addition to the data above, a user agent might also store
+                ambient information about the call, such as the URI associated
+                with the <a>top-level browsing context</a>,
+                the <a>effective script origin</a>, a current timestamp, or other
+                information potentially obtained from applicable tracking status
+                resources.
+            </p>
+            <p>
+                The calling site MUST have a
+                <a>site-wide tracking status resource</a> with a valid
+                <a href="#status-representation">tracking status representation</a>
+                that includes a <a>policy</a> property.
+                This allows a user agent to obtain and possibly store additional
+                information about the calling site’s controller and tracking
+                policies at the time an exception is granted.
+            </p>
+            <p>
+                A user agent MAY reject the promise with a <a>DOMException</a>
+                named "InvalidStateError" if it cannot determine the
+                <a>effective script origin</a> or if the site corresponding to that
+                origin does not have a
+                <a>site-wide tracking status resource</a> with a valid
+                <a href="#status-representation">tracking status representation</a>.
+            </p>
+            <p>
+                For a <a>site-specific</a> exception,
+                a user agent MUST NOT store the duplets and MUST reject the
+                promise with a <a>DOMException</a> named "SecurityError"
+                if the script's <a>effective script origin</a> would not be able
+                to set a cookie on the <a data-link-for="TrackingExData">site</a>
+                following the cookie domain rules [[!RFC6265]],
+            </p>
+            <p class="example">
+                For example, a script on <em>www.foo.bar.example.com</em> can set
+                the <a data-link-for="TrackingExData">site</a> as
+                <code>"bar.example.com"</code> or
+                <code>"example.com"</code>, but not to
+                <code>"something.else.example.com"</code> or <code>"com"</code>.
+            </p>
+            <p>
+                For each of the <a data-link-for="TrackingExData">targets</a> in a
+                <a>web-wide</a> exception, a user agent MUST NOT store the duplets
+                and MUST reject the promise with a <a>DOMException</a> named
+                "SecurityError" unless the target domain matches the
+                <a>document.domain</a> of the script's <a>responsible document</a>
+                [[!HTML5]]. This effectively limits the API for web-wide exceptions
+                to the single <a>effective script origin</a> domain of the caller.
+            </p>
+            <p>
+                For any other failure, such as an incorrectly formatted parameter in
+                the <a>TrackingExData</a>, the user agent MUST NOT store
+                any of the target duplets in the database and MUST reject the promise
+                with a <a>DOMException</a> named "SyntaxError".
+            </p>
+            <p>
+                <a>Upon fulfillment</a>, the user agent has added to its local
+                database one or more site-pair duplets [site, target], each
+                indicating that a request from that <a>site domain</a> to the
+                <a>target domain</a> will include <a>DNT:0</a> regardless of the
+                user's general tracking preference. The fulfilled promise object
+                contains the following <a>TrackingExResult</a> attribute:
+            </p>
+            <dl data-dfn-for="TrackingExResult">
+                <dt><code><dfn>isSiteWide</dfn></code></dt>
+                <dd>
+                    <code>true</code> if the user agent stored a potentially
+                    broader exception that applies to all domains (as opposed to just
+                    the listed targets); otherwise, <code>false</code>.
+                </dd>
+            </dl>
+            <p>
+                When a list of <a data-link-for="TrackingExData">targets</a>
+                is supplied for a <a>site-specific</a> exception (i.e., a
+                <a data-link-for="TrackingExData">site</a> other
+                than "*"), the user agent MAY ignore that list, choosing instead to
+                store a <a>site-specific</a> exception for all domains
+                (<code>[site,&nbsp;*]</code>), if it also indicates that result by
+                setting the returned promise's
+                <a data-link-for="TrackingExResult">isSiteWide</a> property
+                to <code>true</code>.
+            </p>
+            <p>
+                User agents MAY instantiate <a>Navigator.storeTrackingException</a>
+                even when <a>Navigator.doNotTrack</a> is null. Scripts SHOULD test
+                for the existence of <a>Navigator.storeTrackingException</a> before
+                calling the method.
+            </p>
+            <p class="note" id="api-security">
+                There are some security concerns here regarding the ability of a
+                script with an <a>effective script origin</a> different from the
+                site being able to set site-specific exceptions that might impact
+                the behavior of that site. Likewise, it might be unwise for a script
+                to be able to impact the DNT values received by target domains when
+                the <a>effective script origin</a> differs from those targets.
+                However, a solution to these concerns would require additional
+                requests to verify that the <a>effective script origin</a> has the
+                right to set DNT for the given duplets, which is overkill given how
+                little value is obtained by setting the field without a legitimate
+                record of consent having been received.<br />
+                <br />
+                This design is consistent with the fact that there is no technical
+                restraint from sites calling the API without having first obtained
+                an informed consent from the user. What we are assuming is that the
+                surrounding regulatory environment will be sufficient to punish
+                those who might misuse the API or abuse the scope of stored
+                exceptions.
+            </p>
+        </section>
+
+        <section id="exception-javascript-api-cancel">
+            <h4>API to Remove a Tracking Exception</h4>
+            <p>
+                When a site decides, or has been directed by the user, to revoke a
+                <a>user-granted exception</a>, a script running within an active
+                <a>browsing context</a> or <a>nested browsing context</a> of that
+                site can <a>promise-call</a>
+                <code><dfn>Navigator.removeTrackingException</dfn></code>
+                to remove one or more tracking exceptions.
+                A <a>TrackingExData</a> object is supplied as a
+                parameter to identify which exceptions are to be removed.
+                The call returns a promise which either resolves to
+                indicate success or is rejected with a <a>DOMException</a>
+                identifying the reason for the failure.
+            </p>
+            <pre class="idl">
+        partial interface Navigator {
+          Promise&lt;void&gt; removeTrackingException (
+            TrackingExData properties
+          );
+        };
+        </pre>
+            <p>
+                <a>Navigator.removeTrackingException</a> passes a
+                <a>TrackingExData</a> object. A user agent MUST ignore unknown
+                properties of the <a>TrackingExData</a> object (for future
+                extensibility). The following OPTIONAL properties are defined:
+            </p>
+            <dl>
+                <dt><a data-link-for="TrackingExData">site</a></dt>
+                <dd>
+                    The referring domain scope from which the exception should be
+                    removed:
+                    <ul>
+                        <li>
+                            If
+                            <a data-link-for="TrackingExData">site</a> is
+                            undefined, null, or the empty string, the calling script's
+                            <a>effective script origin</a> is used by default.
+                            All stored exceptions matching that domain, regardless of
+                            target, are to be removed.
+                        </li>
+                        <li>
+                            If
+                            <a data-link-for="TrackingExData">site</a> is
+                            defined and equal to "<code>*</code>", the exception to be
+                            removed, regardless of target, is <a>web-wide</a> for
+                            the <a>effective script origin</a>.
+                        </li>
+                        <li>
+                            Otherwise, the exceptions to be removed are identified by a
+                            domain found in
+                            <a data-link-for="TrackingExData">site</a>
+                            that is treated in the same way as the domain parameter to
+                            cookies [[!RFC6265]], allowing subdomains to be included with
+                            the prefix "<code>*.</code>". All stored exceptions matching
+                            that domain, regardless of target, are to be removed.
+                        </li>
+                    </ul>
+                </dd>
+                <dt><a data-link-for="TrackingExData">targets</a></dt>
+                <dd>
+                    An array of target domains for which the exception applies:
+                    <ul>
+                        <li>
+                            If <a data-link-for="TrackingExData">site</a> is
+                            defined and equal to "<code>*</code>", then for each domain
+                            string in the
+                            <a data-link-for="TrackingExData">targets</a>
+                            array, a <a>web-wide</a> exception to be removed is the duplet
+                            <code>[*,&nbsp;domain]</code>.
+                        </li>
+                        <li>
+                            Otherwise,
+                            <a data-link-for="TrackingExData">targets</a>
+                            is ignored.
+                        </li>
+                    </ul>
+                </dd>
+            </dl>
+            <p>
+                For a <a>site-specific</a> exception,
+                a user agent MUST NOT remove the duplets and MUST reject the
+                promise with a <a>DOMException</a> named "SecurityError"
+                if the script's <a>effective script origin</a>
+                would not be able to set a
+                cookie on the <a data-link-for="TrackingExData">site</a>
+                following the cookie domain rules [[!RFC6265]],
+            </p>
+            <p>
+                For each of the <a data-link-for="TrackingExData">targets</a> in a
+                <a>web-wide</a> exception, a user agent MUST NOT remove the duplets
+                and MUST reject the promise with a <a>DOMException</a> named
+                "SecurityError" unless the target domain matches both the
+                <a>document.domain</a> of the script's <a>responsible document</a>
+                and the
+                <a>document.domain</a> of the <a>top-level browsing context</a>'s
+                <a>active document</a> [[!HTML5]]. This effectively limits the API
+                for web-wide exceptions to the single target domain of the caller.
+            </p>
+            <p>
+                Any processing failure, such as an incorrectly formatted parameter
+                in the <a>TrackingExData</a>, will result in no duplet
+                being removed from the database of stored grants and the
+                returned promise being rejected with a
+                <a>DOMException</a> named "SyntaxError".
+            </p>
+            <p>
+                If there are no matching duplets in the database of stored
+                grants when the method is called, this operation does nothing
+                other than resolve the promise.
+            </p>
+            <p>
+                <a>Upon fulfillment</a>, the user agent MUST have removed any
+                stored exceptions that matched the identified duplet(s).
+            </p>
+        </section>
+
+      <section id="exception-javascript-api-confirm">
+        <h4>API to Confirm a Tracking Exception</h4>
+
+        <p>
+          When a site wishes to confirm that a <a>user-granted exception</a>
+          exists for a set of target domains potentially referenced by that
+          site, a script running within an active <a>browsing context</a> or
+          <a>nested browsing context</a> of that site can <a>promise-call</a>
+          <code><dfn>Navigator.trackingExceptionExists</dfn></code> with a
+          <a>TrackingExData</a> object supplied as a parameter that identifies
+          targets for which to confirm an exception exists.
+          The call returns a promise which either resolves to true or
+          false or is rejected with a <a>DOMException</a>
+          identifying the reason for the failure.
+        </p>
+        <pre class="idl">
+        partial interface Navigator {
+          Promise&lt;boolean&gt; trackingExceptionExists (
+            TrackingExData properties
+          );
+        };
+        </pre>
+        <p>
+          <a>Navigator.trackingExceptionExists</a> passes a
+          <a>TrackingExData</a> object. A user agent MUST ignore unknown
+          properties of the <a>TrackingExData</a> object (for future
+          extensibility). The following OPTIONAL properties are defined:
+        </p>
+        <dl>
+          <dt><a data-link-for="TrackingExData">site</a></dt>
+          <dd>The referring domain scope:
+              <ul>
+                  <li>
+                      If
+                      <a data-link-for="TrackingExData">site</a> is
+                      undefined, null, or the empty string, the check
+                      is for a site-specific exception in the
+                      <a>effective script origin</a>.
+                  </li>
+                  <li>
+                      If
+                      <a data-link-for="TrackingExData">site</a> is
+                      defined and equal to "<code>*</code>", the check
+                      is for a <a>web-wide</a> exception for the
+                      <a>effective script origin</a>, regardless of target.
+                  </li>
+                  <li>
+                      Otherwise, the referring domain scope to be checked
+                      for an exception is defined by a domain found
+                      in <a data-link-for="TrackingExData">site</a>
+                      that is treated in the same way as the domain parameter to
+                      cookies [[!RFC6265]], allowing subdomains to be included with
+                      the prefix "<code>*.</code>". The value
+                      can be set to a fully-qualified right-hand segment of the
+                      document host name, up to one level below TLD.
+                  </li>
+              </ul></dd>
+          <dt><a data-link-for="TrackingExData">targets</a></dt>
+          <dd>An array of target domains:
+            <ul>
+              <li>If <a data-link-for="TrackingExData">targets</a>
+                is undefined, null, or an empty array, the duplet
+                <code>[site,&nbsp;*]</code> (an exception applicable to all
+                domains referenced by the site) is identified for matching
+                against the database of stored user-granted exceptions.</li>
+              <li>Otherwise, for each domain string in the
+                <a data-link-for="TrackingExData">targets</a> array, the
+                duplet <code>[site,&nbsp;domain]</code> is identified for
+                matching against the database of stored
+                user-granted exceptions.</li>
+            </ul></dd>
+        </dl>
+        <p>
+          Any processing failure, such as an incorrectly formatted parameter
+          in the <a>TrackingExData</a>, will result in the
+          returned promise being rejected with a
+          <a>DOMException</a> named "SyntaxError".
+        </p>
+        <p>
+          A user agent MUST fulfill the promise with the value
+          <code>true</code> if a current (non-expired) matching exception
+          exists for all of the duplets identified above, or
+          <code>false</code> if any of the identified duplets do not have a
+          matching exception.
+        </p>
+        <p>
+          Because the database might be changed at any time (via other windows
+          or additional user interfaces), a particular response to the API
+          might only be accurate at the time the promise is fulfilled.
+        </p>
+        <p class="note">
+          This API does not allow a script to directly confirm that a
+          <a>web-wide</a> exception (<code>[*,&nbsp;target]</code>) exists, since
+          that would allow too much of the user's personal configuration,
+          including exceptions set while on other sites, to be visible to
+          arbitrary scripts on the active site. However, it might be
+          reasonable (in the future) to add an API that allows a script
+          to check for a <a>web-wide</a> exception targeting its own domain
+          (i.e., matching the domain in its <a>effective script origin</a>).
+        </p>
+      </section>
+    </section>
+
+    <section id='exception-management'>
+      <h3>User Agent Management of Exceptions</h3>
+
+      <p>
+        There is no required user interface for a user agent regarding the
+        granting of exceptions; a user agent MAY choose to provide none.
+        Alternatively, a user agent MAY:
+      </p>
+      <ul>
+        <li>indicate that a call to store an exception has just been
+          made;</li>
+        <li>allow the user to confirm a user-granted exception prior
+          to storage;</li>
+        <li>indicate that one or more exceptions exist for the
+          current site;</li>
+        <li>indicate that one or more exceptions exist for target domains
+          incorporated into the current page; or,</li>
+        <li>provide a user interface to see and edit the database of recorded
+          exception grants.</li>
+      </ul>
+      <p>
+        When an explicit list of target domains is provided through the API,
+        their names might mean little to the user. The user might, for
+        example, be told that there is a stored exception for a specific
+        set of targets on such-and-such site, rather than
+        listing them by name; or the user agent might decide to store an
+        all-target exception, effectively ignoring any list of targets.
+      </p>
+      <p>
+        Conversely, if a wild-card is used for the target, the user might be
+        told that there is a stored exception for all third parties that are
+        embedded by the indicated site.
+      </p>
+      <p>
+        A user agent that chooses to highlight when tracking exceptions are
+        applicable might provide an interface, such as a selectable icon in
+        the status bar, that can direct the user to more information about
+        the exception and how to revoke it.
+      </p>
+      <p>
+        In some user agent implementations, decisions to grant exceptions
+        might have been made in the past (and since forgotten) or might have
+        been made by other users of the device. Thus, exceptions might not
+        always represent the current preferences of the user. Some user
+        agents might choose to provide ambient notice that user-opted
+        tracking is ongoing, or easy access to view and control these
+        preferences. Users might also desire to edit exceptions within a
+        separate user interface, which would allow a user to modify their
+        stored exceptions without visiting the target sites.
+      </p>
+      <p>
+        A user-agent MUST handle each set of exception duplets stored by a
+        single storeTrackingException call as a 'unit', granting and
+        maintaining the duplets in their entirety, or not at all.
+        A user agent MUST NOT indicate to a site that it has stored an
+        exception for targets {a, b, c} in the database, and later remove
+        only one or two of {a, b, c} from its logical database of stored
+        grants. This assures sites that the set of target domains they need
+        for operational integrity is treated as a unit.
+      </p>
+    </section>
+  </section>
+
+  <section id='responding'>
+    <h2>Communicating a Tracking Status</h2>
+
+    <section id='response-overview'>
+      <h3>Overview</h3>
+
+      <p>
+        In addition to expressing the user's preference regarding tracking,
+        this protocol enables servers to communicate machine-readable claims
+        regarding their own tracking behavior. Since a personalized tracking
+        status on every response would disable caching, a combination of
+        response mechanisms are defined to allow the tracking status to be
+        communicated prior to making a trackable request and without making
+        every response dynamic.
+      </p>
+    </section>
+
+    <section id='tracking-status-value'>
+      <h3>Tracking Status Value</h3>
+
+      <section id='TSV-defn'>
+        <h4>Definition</h4>
+        <p>
+          A <dfn>tracking status value</dfn> (<dfn>TSV</dfn>) is a single
+          character response to the user's tracking preference with regard to
+          data collected via the <dfn>designated resource</dfn>.
+          For a site-wide tracking status resource, the designated resource
+          is any resource on the same origin server.
+          For a <a>Tk</a> response header field, the <a>target resource</a> of the
+          corresponding request is the designated resource, and remains so
+          for any subsequent request-specific tracking status resource
+          referred to by the Tk field value.
+        </p>
+        <p>
+          The tracking status value is case sensitive, as defined formally
+          by the following ABNF.
+        </p>
+<pre class="abnf">
+TSV    = %x21   ; "!" — under construction
+       / %x3F   ; "?" — dynamic
+       / %x47   ; "G" — gateway to multiple parties
+       / %x4E   ; "N" — not tracking
+       / %x54   ; "T" — tracking
+       / %x43   ; "C" — tracking with consent
+       / %x50   ; "P" — tracking only if consented
+       / %x44   ; "D" — disregarding DNT
+       / %x55   ; "U" — updated
+       / TSV-extension
+</pre>
+      </section>
+
+      <section id='TSV-!'>
+        <h4>Under Construction (!)</h4>
+        <p>
+          A tracking status value of <code><dfn>!</dfn></code> means that the origin
+          server is currently testing its communication of tracking status.
+          The <code>!</code> value has been provided to ease testing and
+          deployment on production systems during the initial periods of
+          testing compliance and during adjustment periods due to future
+          protocol changes or shifting regulatory constraints. Note that
+          this value does not indicate that the user's preference will be
+          ignored, nor that tracking will occur as a result of accessing
+          the designated resource.
+        </p>
+      </section>
+
+      <section id='TSV-?'>
+        <h4>Dynamic (?)</h4>
+        <p>
+          A tracking status value of <code><dfn>?</dfn></code> means the origin server
+          needs more information to determine tracking status, usually
+          because the <a>designated resource</a> dynamically adjusts
+          behavior based on information in a request.
+        </p>
+        <p>
+          If <code>?</code> is present in the site-wide tracking status,
+          the origin server MUST send a <a>Tk</a> header field in all
+          responses to requests on the designated resource.
+          If <code>?</code> is present in the <a>Tk</a> header field,
+          more information will be provided in a request-specific
+          tracking status resource referred to by the <a>status-id</a>.
+          An origin server MUST NOT send <code>?</code> as the
+          tracking status value in the representation of a
+          request-specific tracking status resource.
+        </p>
+      </section>
+
+      <section id='TSV-G'>
+        <h4>Gateway (G)</h4>
+        <p>
+          A tracking status value of <code><dfn>G</dfn></code> means the server
+          is acting as a gateway to an exchange involving multiple parties.
+          This might occur if a response to the <a>designated resource</a>
+          involves an automated selection process, such as dynamic bidding,
+          where the party that is selected determines how the request data
+          will be treated with respect to an expressed tracking preference.
+          Similar to the <a>?</a> value, the <code>G</code> TSV
+          indicates that the actual tracking status is dynamic and will be
+          provided in the response message's <a>Tk</a> header field,
+          presumably using information forwarded from the selected party.
+        </p>
+        <p>
+          This tracking status value is only valid as a site-wide status.
+          A server MUST NOT send <code>G</code> as the
+          tracking status value in a <a>Tk</a> header field or within the
+          representation of a request-specific tracking status resource.
+        </p>
+        <p>
+          If <code>G</code> is present in the site-wide tracking status:
+        </p>
+        <ul>
+          <li>the gateway MUST send a link within its site-wide
+            tracking status representation to a privacy policy that
+            explains what limitations are placed on parties that
+            might receive data via that gateway;</li>
+          <li>the gateway MUST forward any expressed tracking
+            preference in the request to each party that receives data
+            from that request;</li>
+          <li>the gateway MUST have a contract in place with each of the
+            parties to whom it provides request data such that only the
+            selected party is allowed to retain tracking data from a
+            request with an expressed tracking preference of
+            <a>DNT:1</a>; and,</li>
+          <li>the gateway MUST send a <a>Tk</a> header field in
+            responses to requests on the designated resource and include
+            within that field's value a <a>status-id</a>
+            specific to the selected party, such that information about
+            the selected party can be obtained via the request-specific
+            tracking status resource (see
+            <a href="#request-specific-status-resource" class="sectionRef"></a>).</li>
+        </ul>
+        <p>
+          With respect to tracking performed by the gateway itself, the
+          <code>G</code> response can be considered equivalent
+          to the <a>T</a> (tracking) response defined below.
+          The other information within the site-wide tracking status
+          representation indicates how the gateway intends to comply
+          with an expressed tracking preference, aside from the potential
+          sharing of data implied by the gateway process.
+        </p>
+      </section>
+
+      <section id='TSV-N'>
+        <h4>Not Tracking (N)</h4>
+        <p>
+          A tracking status value of <code><dfn>N</dfn></code> means the origin server
+          claims that data collected via the <a>designated resource</a> is
+          not used for tracking and will not be combined with other data in
+          a form that would enable tracking.
+        </p>
+      </section>
+
+      <section id='TSV-T'>
+        <h4>Tracking (T)</h4>
+        <p>
+          A tracking status value of <code><dfn>T</dfn></code> means the origin server
+          might perform or enable tracking using data collected via the
+          <a>designated resource</a>. Information provided in the tracking
+          status representation might indicate whether such tracking is
+          limited to a set of commonly accepted uses or adheres to one or
+          more compliance regimes.
+        </p>
+      </section>
+
+      <section id='TSV-C'>
+        <h4>Consent (C)</h4>
+        <p>
+          A tracking status value of <code><dfn>C</dfn></code> means that the origin
+          server believes it has received prior consent for tracking this
+          user, user agent, or device, perhaps via some mechanism not
+          defined by this specification, and that prior consent overrides
+          the tracking preference expressed by this protocol.
+          An origin server that sends the <code>C</code> tracking status
+          value for a <a>designated resource</a> MUST provide a reference
+          for controlling consent within the <a>config</a>
+          property of its corresponding tracking status representation
+          (<a href="#status-representation" class="sectionRef"></a>).
+        </p>
+      </section>
+
+      <section id='TSV-P'>
+        <h4>Potential Consent (P)</h4>
+        <p>
+          A tracking status value of <code><dfn>P</dfn></code> means that the origin
+          server does not know, in real-time, whether it has received prior
+          consent for tracking this user, user agent, or device, but
+          promises not to use or share any <a>DNT:1</a> data
+          until such consent has been determined, and further promises to
+          delete or <a href="#dfn-permanently-de-identified">permanently de-identify</a>
+          within forty-eight hours any <a>DNT:1</a> data
+          received for which such consent has not been received.
+        </p>
+        <p>
+          Since this status value does not itself indicate whether a
+          specific request is tracked, an origin server that sends a
+          <code>P</code> tracking status value MUST provide a
+          <a>config</a> property in the corresponding tracking
+          status representation that links to a resource for obtaining
+          consent status.
+        </p>
+        <p>
+          The <code>P</code> tracking status value is specifically meant to
+          address audience survey systems for which determining consent at
+          the time of a request is either impractical, due to legacy systems
+          not being able to keep up with Web traffic, or potentially "gamed"
+          by first party sites if they can determine which of their users
+          have consented. The data cannot be used for the sake of
+          personalization. If consent can be determined at the time of a
+          request, the <a>C</a> tracking status is preferred.
+        </p>
+      </section>
+
+      <section id='TSV-D'>
+        <h4>Disregarding (D)</h4>
+        <p>
+          A tracking status value of <code><dfn>D</dfn></code> means that the origin
+          server is unable or unwilling to respect a tracking preference
+          received from the requesting user agent.  An origin server that
+          sends the <code>D</code> tracking status value MUST detail within
+          the server's corresponding privacy policy the conditions under
+          which a tracking preference might be disregarded.
+        </p>
+        <p>
+          For example, an origin server might disregard the DNT field
+          received from specific user agents (or via specific network
+          intermediaries) that are deemed to be non-conforming, might be
+          collecting additional data from specific source network
+          locations due to prior security incidents, or might be
+          compelled to disregard certain DNT requests to comply with a
+          local law, regulation, or order.
+        </p>
+        <p class="note">
+          This specification is written with an assumption that the
+          <code>D</code> tracking status value would only be used in
+          situations that can be adequately described to users as an
+          exception to normal behavior. If this turns out not to be the
+          case, either the server's decision to send the <code>D</code>
+          signal needs re-examination, or this specification, or both.
+        </p>
+      </section>
+
+      <section id='TSV-U'>
+        <h4>Updated (U)</h4>
+        <p>
+          A tracking status value of <code><dfn>U</dfn></code> means that the request
+          resulted in a potential change to the tracking status applicable
+          to this user, user agent, or device. A user agent that relies on a
+          cached tracking status SHOULD update the cache entry with the
+          current status by making a new request on the applicable tracking
+          status resource.
+        </p>
+        <p>
+          An origin server MUST NOT send <code>U</code> as a tracking status
+          value anywhere other than a <a>Tk</a> header field that is in
+          response to a state-changing request.
+        </p>
+      </section>
+
+      <section id='TSV.extension'>
+        <h4>Extensions to the Tracking Status Value</h4>
+        <p>
+          Extensibility of the <a>TSV</a> set ensures that this protocol will
+          continue to be usable as regional laws and regulatory environments
+          evolve over time and compliance specifications are developed
+          accordingly.
+        </p>
+        <p>
+          An origin server MAY send a <dfn>TSV-extension</dfn> character as a
+          <a>TSV</a> if that extension has been defined by a future version
+          of this specification or a compliance regime identified within the
+          <a>compliance</a> property. Aside from storage or presentation of a
+          server's response, a recipient MUST treat a TSV-extension value that
+          it does not recognize as if the value was <a>P</a> (tracking only
+          if consented).
+        </p>
+<pre class="abnf">
+TSV-extension = %x23-25  ; #$%
+              / %x2A-3B  ; *+,-./0-9:;
+              / %x40-42  ; @AB
+              / %x45-46  ; EF
+              / %x48-4D  ; HIJKLM
+              / %x4F     ; O
+              / %x51-53  ; QRS
+              / %x56-5A  ; VWXYZ
+              / %x5F     ; _
+              / %x61-7A  ; a-z
+</pre>
+      </section>
+    </section>
+
+    <section id='response-header-field'>
+      <h3>Tk Header Field for HTTP Responses</h3>
+
+      <section id='Tk-header-defn'>
+        <h4>Definition</h4>
+
+        <p>
+          The <code><dfn>Tk</dfn></code> response header field is a means for indicating
+          the tracking status that applied to the corresponding request.
+          An origin server is REQUIRED to send a <code>Tk</code> header
+          field if its site-wide tracking status value is <a>?</a>
+          (dynamic) or <a>G</a> (gateway), or when an interactive change is
+          made to the tracking status and indicated by <a>U</a> (updated).
+        </p>
+<pre class="abnf">
+Tk-field-name   =  "Tk"
+Tk-field-value  =  TSV [ ";" status-id ]
+</pre>
+        <p>
+          The Tk field-value begins with a tracking status value
+          (<a href="#tracking-status-value" class="sectionRef"></a>),
+          optionally followed by a semicolon and a <code>status-id</code>
+          that refers to a request-specific tracking status resource
+          (<a href="#referring-status-id" class="sectionRef"></a>).
+        </p>
+        <p>
+          For example, a Tk header field for a resource that claims not to
+          be tracking would look like:
+        </p>
+        <pre class="example">Tk: N</pre>
+      </section>
+
+      <section id='referring-status-id'>
+        <h4>Referring to a Request-specific Tracking Status Resource</h4>
+        <p>
+          If an origin server has multiple, request-specific tracking
+          policies, such that the tracking status might differ depending on
+          some aspect of the request (e.g., method, <a>target resource</a>, header
+          fields, data, etc.), the origin server can provide an additional
+          subtree of well-known resources corresponding to each of those
+          distinct tracking statuses. The <code><dfn>status-id</dfn></code>
+          portion of the <code>Tk</code> field-value indicates which specific
+          tracking status resource applies to the current request.
+          The <code>status-id</code> is case-sensitive.
+        </p>
+<pre class="abnf">
+status-id       =  1*id-char
+id-char         =  ALPHA / DIGIT / "_" / "-" / "+" / "=" / "/"
+</pre>
+        <p>
+          For example, a response containing
+        </p>
+        <pre class="example">Tk: T;fRx42</pre>
+        <p>
+          indicates that data collected via the target resource might be
+          used for tracking and that an applicable tracking status
+          representation can be obtained by performing a retrieval request
+          on
+        </p>
+        <pre>/.well-known/dnt/fRx42</pre>
+        <p>
+          Note that the <code>status-id</code> is resolved relative
+          to the origin server of the current request.  A retrieval request
+          targeting that URI can be redirected, if desired, to some other
+          server.  The <code>status-id</code> has been intentionally limited
+          to a small set of characters to encourage use of short tokens
+          instead of potentially long, human-readable strings.
+        </p>
+        <p>
+          If a Tk field-value has a tracking status value of
+          <a>?</a> (dynamic), the origin server MUST
+          send a <code>status-id</code> in the field-value.
+        </p>
+      </section>
+
+      <section id='interactive-status-change'>
+        <h4>Indicating an Interactive Status Change</h4>
+        <p>
+          Interactive mechanisms might be used, beyond
+          the scope of this specification, that have the effect of asking
+          for and obtaining prior consent for tracking, or for modifying
+          prior indications of consent.  For example, the tracking status
+          resource's status object defines a <a>config</a>
+          property that can refer to such a mechanism. Although such
+          out-of-band mechanisms are not defined by this specification,
+          their presence might influence the tracking status object's
+          response value.
+        </p>
+        <p>
+          When an origin server provides a mechanism via HTTP for
+          establishing or modifying out-of-band tracking preferences,
+          the origin server MUST indicate within the mechanism's response
+          when a state-changing request has resulted in a change to the
+          tracking status for that server.  This indication of an
+          interactive status change is accomplished by sending a
+          <a>Tk</a> header field in the response with a tracking status
+          value of <a>U</a> (updated).
+        </p>
+        <pre class="example">Tk: U</pre>
+      </section>
+    </section>
+
+    <section id='status-resource'>
+      <h3>Tracking Status Resource</h3>
+
+      <section id='site-wide-status-resource'>
+        <h4>Site-wide Tracking Status</h4>
+        <p>
+          A <dfn>site-wide tracking status resource</dfn> provides
+          information about the potential tracking behavior of resources
+          located at that origin server. A site-wide tracking status
+          resource has the well-known identifier
+        </p>
+        <pre>/.well-known/dnt/</pre>
+        <p>
+          relative to the origin server's URI [[RFC5785]].
+        </p>
+        <p>
+          An origin server that receives a valid <code>GET</code> request
+          targeting its site-wide tracking status resource MUST send either
+          a successful response containing a machine-readable representation
+          of the site-wide tracking status, as defined below, or a sequence
+          of redirects that leads to such a representation. Failure to
+          provide access to such a representation implies that the
+          origin server does not implement this protocol.
+          The representation can be cached, as described
+          in <a href="#status-caching" class="sectionRef"></a>.
+        </p>
+        <p>
+          See <a href="#use-cases" class="sectionRef"></a> for
+          examples of how tracking status resources can be used to discover
+          support for this protocol.
+        </p>
+      </section>
+
+      <section id='request-specific-status-resource'>
+        <h4>Request-specific Tracking Status</h4>
+        <p>
+          If an origin server has multiple, request-specific tracking
+          policies, such that the tracking status might differ depending on
+          some aspect of the request (e.g., method, target resource, header
+          fields, data, etc.), the origin server can provide an additional
+          subtree of well-known resources corresponding to each of those
+          distinct tracking statuses.  The <a>Tk</a> response header field
+          (<a href="#response-header-field" class="sectionRef"></a>) can
+          include a <a>status-id</a> to indicate which specific
+          tracking status resource applies to the current request.
+        </p>
+        <p>
+          A <dfn>tracking status resource space</dfn> is defined by the
+          following URI Template [[RFC6570]]:
+        </p>
+        <pre>/.well-known/dnt/{+status-id}</pre>
+        <p>
+          where the value of <a>status-id</a> is a string of URI-safe
+          characters provided by a <a>Tk</a> field-value in response to a
+          prior request.  For example, a prior response containing
+        </p>
+        <pre class="example">Tk: ?;ahoy</pre>
+        <p>
+          refers to the specific tracking status resource
+        </p>
+        <pre>/.well-known/dnt/ahoy</pre>
+        <p>
+          Resources within the request-specific tracking status resource
+          space are represented using the same format as a site-wide
+          tracking status resource.
+        </p>
+      </section>
+
+      <section id='status-checks-not-tracked'>
+        <h4>Status Checks are Not Tracked</h4>
+        <p>
+          When sending a request for the tracking status, a user agent
+          SHOULD include any cookie data [[RFC6265]] (set prior to the
+          request) that would be sent in a normal request to that origin
+          server, since that data might be needed by the server to determine
+          the current tracking status. For example, the cookie data might
+          indicate a prior out-of-band decision by the user to opt-out or
+          consent to tracking by that origin server.
+        </p>
+        <p>
+          An origin server MUST NOT retain tracking data regarding requests
+          on the site-wide tracking status resource or within the tracking
+          status resource space, regardless of the presence, absence, or
+          value of a DNT header field, cookies, or any other information in
+          the request.
+          In addition, an origin server MUST NOT send Set-Cookie or
+          Set-Cookie2 header fields in responses to those requests,
+          including the responses to redirected tracking status requests,
+          and MUST NOT send a response having content that initiates
+          tracking beyond what was already present in the request.
+          A user agent SHOULD ignore, or treat as an error, any Set-Cookie
+          or Set-Cookie2 header field received in such a response.
+        </p>
+      </section>
+
+      <section id='status-caching'>
+        <h4>Caching</h4>
+        <p>
+          If the tracking status is applicable to all users, regardless of
+          the received <a>DNT</a> field-value and other data received via the
+          request, then the origin server SHOULD mark the response as
+          cacheable [[!RFC7234]] and assign a time-to-live (expiration or
+          max-use) that is sufficient to enable shared caching but not
+          greater than the earliest point at which the service's tracking
+          behavior might increase.
+        </p>
+        <p>
+          For example, if the tracking status response is set to expire in
+          seven days, then the earliest point in time that the service's
+          tracking behavior can be increased is seven days after the
+          tracking status representation has been
+          updated to reflect the new behavior, since old copies might
+          persist in caches until the expiration is triggered. A service's
+          tracking behavior can be reduced at any time, with or without a
+          corresponding change to the tracking status resource.
+        </p>
+        <p>
+          If the tracking status is only applicable to users that have
+          the same <a>DNT</a> field-value, the origin server MUST send a
+          Vary header field that includes "DNT" in its field-value or a
+          Cache-Control header field containing one of the following
+          directives: "private", "no-cache", "no-store", or "max-age=0".
+        </p>
+        <p>
+          If the tracking status is only applicable to the specific user
+          that requested it, then the origin server MUST send a
+          Cache-Control header field containing one of the following
+          directives: "private", "no-cache", or "no-store".
+        </p>
+        <p>
+          Regardless of the cache-control settings, it is expected that
+          user agents will check the tracking status of a service only once
+          per session (at most).  A public Internet site that intends to
+          change its tracking status to increase tracking behavior MUST
+          update the tracking status resource in accordance with that
+          planned behavior at least twenty-four hours prior to activating
+          that new behavior on the service.
+        </p>
+        <p>
+          A user agent that adjusts behavior based on active verification
+          of tracking status, relying on cached tracking status responses
+          to do so, SHOULD check responses to its state-changing requests
+          (e.g., POST, PUT, DELETE, etc.) for a <a>Tk</a> header field
+          with the <a>U</a> tracking status value, as described in
+          <a href="#interactive-status-change" class="sectionRef"></a>.
+        </p>
+      </section>
+    </section>
+
+    <section id='status-representation'>
+      <h3>Tracking Status Representation</h3>
+      <p>
+        For each tracking status resource, an origin server MUST provide a
+        valid representation using the
+        <code><dfn>application/tracking-status+json</dfn></code> media type.
+        This media type consists of a <a>status object</a>
+        serialized as JSON [[!RFC7159]]. More information about the
+        <code>application/tracking-status+json</code> media type can be
+        found in <a href="#registrations" class="sectionRef"></a>.
+      </p>
+
+      <section id='rep.status-object'>
+        <h4>Status Object</h4>
+        <p>
+          A tracking status representation consists of a single
+          <dfn>status object</dfn> containing properties that
+          describe the tracking status applicable to the
+          <a>designated resource</a>.  Most of the properties are optional
+          and can be <a href="#rep.extension">extended over time</a>,
+          as illustrated by the following Orderly schema [[Orderly]]:
+        </p>
+<pre class="orderly">
+object {
+    string tracking;                 // TSV
+    array { string; } compliance?;   // hrefs
+    string qualifiers?;              // compliance flags
+    array { string; } controller?;   // hrefs
+    array { string; } same-party?;   // domains
+    array { string; } audit?;        // hrefs
+    string policy?;                  // href
+    string config?;                  // href
+}*;
+</pre>
+
+<p>
+          The following example representation demonstrates a status object
+          with all of the properties defined by this specification.
+        </p>
+<pre class="example">
+{
+  "tracking": "T",
+  "compliance": ["https://acme.example.org/tracking101"],
+  "qualifiers": "afc",
+  "controller": ["https://www.example.com/privacy"],
+  "same-party": [
+    "example.com",
+    "example_vids.net",
+    "example_stats.com"
+  ],
+  "audit": [
+    "http://auditor.example.org/727073"
+  ],
+  "policy": "/privacy.html#tracking",
+  "config": "http://example.com/your/data"
+}
+</pre>
+      </section>
+
+      <section id='rep.tracking'>
+        <h4>Tracking Property</h4>
+        <p>
+          A <a>status object</a> MUST have a property named
+          <code>tracking</code> with a string value containing
+          the tracking status value
+          (<a href="#tracking-status-value" class="sectionRef"></a>)
+          applicable to the <a>designated resource</a>.
+        </p>
+        <p>
+          For example, the following demonstrates a minimal tracking status
+          representation that is applicable to any resource that does not
+          perform tracking.
+        </p>
+<pre class="example">
+{"tracking": "N"}
+</pre>
+      </section>
+
+      <section id='rep.compliance'>
+        <h4>Compliance Property</h4>
+        <p>
+          An origin server MAY send a property named
+          <code><dfn>compliance</dfn></code> with an array value containing
+          a list of URI references that identify specific regimes to which
+          the origin server claims to comply for the designated resource.
+          Communicating such a claim of compliance is presumed to improve
+          transparency, which might influence a user's decisions or
+          configurations regarding allowed tracking.
+        </p>
+        <p>
+          If an origin server sends a <a>TSV-extension</a> or an
+          <a href="#rep.extension">extension property in the status object</a>
+          that is not defined by successors of this specification, the
+          origin server MUST send a <code>compliance</code> property that
+          contains a reference to the definitive specification of that
+          extension. If more than one reference in the <code>compliance</code>
+          array defines the same extension value, the origin server SHOULD
+          list the array of references in order by intended precedence.
+        </p>
+      </section>
+
+      <section id='rep.qualifiers'>
+        <h4>Qualifiers Property</h4>
+        <p>
+          An origin server MAY send a property named
+          <code><dfn>qualifiers</dfn></code> with a string value
+          containing a sequence of case sensitive characters corresponding
+          to explanations or limitations on the extent of tracking.
+          Multiple qualifiers indicate that multiple explanations or forms
+          of tracking might apply for the designated resource.
+          The meaning of each qualifier is presumed to be defined by one
+          or more of the regimes listed in <a>compliance</a>.
+        </p>
+      </section>
+
+      <section id='rep.controller'>
+        <h4>Controller Property</h4>
+        <p>
+          An origin server MAY send a property named
+          <code><dfn>controller</dfn></code> with an array value containing
+          a list of URI references indirectly identifying the party or
+          set of parties that claims to be the responsible data controller
+          for personal data collected via the designated resource. An origin
+          server MUST send a <code>controller</code> property if the
+          responsible data controller does not own the designated resource's
+          domain name.
+        </p>
+        <p>
+          An origin server that does not send <code>controller</code>
+          is implying that its domain owner is the sole data controller;
+          information about the data controller ought to be found on the
+          designated resource's site root page, or by way of a clearly
+          indicated link from that page (i.e., an absent controller property
+          is equivalent to: <code>"controller":["/"]</code>).
+        </p>
+        <p>
+          If the <a>designated resource</a> has joint data controllers
+          (i.e., multiple parties have independent control over the
+          collected data), the origin server MUST send a
+          <code>controller</code> property that contains a reference
+          for each data controller.
+        </p>
+        <p>
+          Each URI reference provided in <code>controller</code> ought to
+          refer to a resource that, if a retrieval action is performed on
+          that URI, would provide the user with information regarding (at a
+          minimum) the identity of the corresponding party and its data
+          collection practices.
+        </p>
+      </section>
+
+      <section id='rep.same-party'>
+        <h4>Same-party Property</h4>
+        <p>
+          Since a user's experience on a given site might be composed of
+          resources that are assembled from multiple domains, it might be
+          useful for a site to distinguish those domains that are subject to
+          their own control (i.e., share the same data controller as the
+          referring site).
+          An origin server MAY send a property named
+          <code><dfn>same-party</dfn></code> with an array value containing
+          a list of domain names that the origin server claims are the same
+          party, to the extent they are referenced by the designated
+          resource, if all data collected via those references share the
+          same data controller as the designated resource.
+        </p>
+        <p>
+          A user agent might use the <code>same-party</code> array,
+          when provided, to inform or enable different behavior for
+          references that are claimed to be same-party versus those for
+          which no claim is made. For example, a user agent might choose to
+          exclude, or perform additional pre-flight verification of,
+          requests to other domains that have not been claimed as same-party
+          by the referring site.
+        </p>
+      </section>
+
+      <section id='rep.audit'>
+        <h4>Audit Property</h4>
+        <p>
+          An origin server MAY send a property named
+          <code><dfn>audit</dfn></code> with an array value containing a
+          list of URI references to external audits of the designated
+          resource's privacy policy and tracking behavior.
+          Preferably, the audit references are to resources that describe
+          the auditor and the results of that audit; however, if such a
+          resource is not available, a reference to the auditor is
+          sufficient.
+        </p>
+      </section>
+
+      <section id='rep.policy'>
+        <h4>Policy Property</h4>
+        <p>
+          An origin server MAY send a property named
+          <code><dfn>policy</dfn></code> with a string value containing a
+          URI reference to a human-readable document that describes the
+          relevant privacy policy for the designated resource.
+          This document can inform users about data that might be collected
+          when the designated resource is accessed and how collection, use,
+          or sharing of such data might differ based on receipt of an
+          expressed tracking preference (<a>DNT:1</a> or <a>DNT:0</a>).
+        </p>
+        <p>
+          An origin server MUST send a <code>policy</code> property if that
+          server is the <a>effective script origin</a> of a script that calls
+          the JavaScript API for storing a <a>user-granted exception</a>, as
+          described in
+          <a href="#exception-granting" class="sectionRef"></a>.
+        </p>
+        <p>
+          The content of such a policy document is beyond the
+          scope of this protocol and only supplemental to what is described
+          in the machine-readable tracking status representation.
+          If no <code>policy</code> property is provided, this
+          information might be obtained via the links provided in
+          <a>controller</a>.
+        </p>
+        <p>
+          If the policy associated with a designated resource happens to be
+          defined as a common standard that is applicable to multiple sites,
+          or includes such a standard by reference, that standard ought to be
+          referenced by a URI within the machine-readable <a>compliance</a>
+          property.
+        </p>
+      </section>
+
+      <section id='rep.config'>
+        <h4>Config Property</h4>
+        <p>
+          An origin server MAY send a property named
+          <code><dfn>config</dfn></code> with a string value containing a
+          URI reference to a resource for giving the user control over
+          personal data collected via the designated resource (and possibly
+          other resources).
+          If the tracking status value indicates prior consent
+          (<a>C</a>), the origin server MUST send a
+          <code>config</code> property referencing a resource that
+          describes how such consent is established and how to revoke that
+          consent.
+        </p>
+        <p>
+          A config resource might include the ability to review
+          past data collected, delete some or all of the data, provide
+          additional data (if desired), or <q>opt-in</q>, <q>opt-out</q>,
+          or otherwise modify an out-of-band consent status regarding
+          data collection. The design of such a resource,
+          the extent to which it can provide access to that data, and
+          how one might implement an out-of-band consent mechanism are
+          beyond the scope of this protocol.
+        </p>
+        <p>
+          If no <code>config</code> property is provided, this
+          information might be obtained via the links provided in
+          <a>controller</a> or <a>policy</a>.
+        </p>
+      </section>
+
+      <section id='rep.extension'>
+        <h4>Extensions to the Status Object</h4>
+        <p>
+          Extensibility of the status object ensures that this protocol will
+          continue to be usable as regional laws and regulatory environments
+          evolve over time and compliance specifications are developed
+          accordingly.
+        </p>
+        <p>
+          An origin server MAY send additional properties in the <a>status
+          object</a> if those extensions have been defined by a future
+          version of this specification or a compliance regime
+          identified within the <a>compliance</a> property.
+          Aside from storage or presentation of a server's response,
+          a recipient MUST ignore extension properties that it does
+          not recognize.
+        </p>
+      </section>
+    </section>
+
+    <section id='response-error'>
+      <h3>Status Code for Tracking Required</h3>
+
+      <p>
+        If an origin server receives a request with <a>DNT:1</a>,
+        does not have out-of-band consent for tracking this user, and
+        wishes to deny access to the requested resource until the user
+        provides some form of user-granted exception or consent for tracking,
+        then the origin server SHOULD send a 409 (Conflict) response with a
+        message payload that describes why the request has been refused and
+        how one might supply the required consent or exception to avoid this
+        conflict [[!RFC7231]].
+      </p>
+      <p>
+        The 409 response ought to include a user authentication mechanism in
+        the header fields and/or message body if user login is one of the
+        ways through which access is granted.
+      </p>
+    </section>
+  </section>
+
+  <section id='use-cases' class="informative">
+      <h3>Use Cases</h3>
+
+      <p class="ednote">
+        This section is for collecting use cases that describe questions a
+        user agent might have about tracking status and how the protocol
+        can be used to answer such questions.  More cases are needed.
+      </p>
+
+      <section id='using-deployment'>
+        <h4>Discovering Deployment</h4>
+        <p>
+          Deployment of this protocol for a given service can
+          be discovered by making a retrieval request on the site-wide
+          tracking resource <q><code>/.well-known/dnt/</code></q> relative
+          to the service URI.
+        </p>
+        <p>
+          If the response is an error, then the service does not implement
+          this standard. If the response is a redirect, then follow the
+          redirect to obtain the tracking status (up to some reasonable
+          maximum of redirects to avoid misconfigured infinite request
+          loops). If the response is successful, obtain the tracking status
+          representation from the message payload, if possible, or consider
+          it an error.
+        </p>
+      </section>
+
+      <section id='using-preflight'>
+        <h4>Preflight Checks</h4>
+        <p>
+          A key advantage of providing the tracking status at a resource
+          separate from the site's normal services is that the status can
+          be accessed and reviewed prior to making use of those services.
+        </p>
+        <p>
+          A user agent can check the tracking status for a
+          <a>designated resource</a> by first making a retrieval request for
+          the site-wide tracking status representation, as described above,
+          and then parsing the representation as JSON to extract the
+          <a>status object</a>.
+          If the retrieval is unsuccessful or parsing results in a syntax
+          error, the user agent ought to consider the site to be
+          non-conformant with this protocol.
+        </p>
+        <p>
+          The <a>status object</a> is supposed to have a
+          property named <code>tracking</code> containing the tracking
+          status value. The meaning of each tracking status value is defined
+          in <a href="#tracking-status-value" class="sectionRef"></a>.
+        </p>
+        <p>
+          If the tracking status value is <a>N</a>, then the origin server
+          claims that no tracking is performed for the designated resource
+          for at least the next 24 hours or until the Cache-Control
+          information indicates that this response expires.
+        </p>
+        <p>
+          If the tracking status value is not <a>N</a>, then the origin
+          server claims that it might track the user agent for requests on
+          the URI being checked for at least the next 24 hours or until the
+          Cache-Control information indicates that this response expires.
+        </p>
+      </section>
+  </section>
+
+  <section id='security'>
+    <h2>Security Considerations</h2>
+
+    <p>
+      Information communicated via the DNT header field is minimized to
+      avoid abuse of the field for fingerprinting or as a side-channel.
+      However, future DNT-extensions might allow for the sending of additional
+      information when signaling consent for tracking via <a>DNT:0</a>,
+      since this consent mechanism is intended to be more persistent than
+      cookies and could be used to convey a pseudonymous identifier as a
+      user-preferred alternative to allowing a cookie to be set.
+    </p>
+    <p>
+      Use of client-side storage is always a security concern. Although the
+      information being stored for each <a>user-granted exception</a> is
+      limited and cannot be directly accessed by scripts, storing too many
+      exceptions might exceed available storage or indicate an attempt to
+      exploit other vulnerabilities.
+    </p>
+    <p>
+      There are also security concerns regarding the ability of scripts to
+      store exceptions beyond the scope of their <a>effective script origin</a>.
+      See the <a href="#api-security">note about API security</a> in
+      <a href="#exception-javascript-api-store" class="sectionRef"></a>.
+    </p>
+  </section>
+
+  <section id='privacy'>
+    <h2>Privacy Considerations</h2>
+
+    <section id='privacy.not-preconfigured'>
+      <h3>Why DNT:1 is Not Preconfigured by Default</h3>
+
+      <p>
+        This specification defines a protocol for communicating the user's
+        tracking preference, not a protocol that prevents tracking on its own.
+        It might be tempting to assume that <q>design for privacy</q> would
+        justify calling for <a>DNT:1</a> to be preconfigured as the default
+        for all user agents. However, that would violate the field's semantics,
+        make its presence in a request meaningless, and add eight extra bytes
+        to every HTTP request (with no effect).
+      </p>
+      <p>
+        The DNT signal alone does nothing to enhance a user's privacy.
+        It is only when recipients believe that the signal has been
+        deliberately and knowingly configured, and not defined as a default,
+        that they will consider it to be the user's preference.
+        Furthermore, when no signal is sent, recipients remain subject to
+        whatever regulatory, legal, or other regional requirements regarding
+        tracking exist in the absence of consent.
+      </p>
+    </section>
+
+      <section id='privacy.fingerprinting'>
+          <h3>Fingerprinting</h3>
+          <p>
+              User-granted exceptions introduce a privacy risk. By storing
+              client-side configurable state and providing functionality to learn
+              about it later, the user-granted exceptions API might facilitate user
+              fingerprinting and tracking.
+          </p>
+          <p>
+              For example an other-origin nested browsing context might create
+              a set of <code>n</code> child browsing contexts then register
+              exceptions for a random subset of them. The resulting <code>n</code>
+              bit identifier could then be re-assembled in subsequent visits using
+              standard cross-origin communication techniques.
+          </p>
+          <p>
+              User agent developers ought to consider
+              the possibility of fingerprinting during implementation and might
+              consider rate-limiting requests, limiting the number of site-specific
+              <a data-link-for="TrackingExData">targets</a> per
+              <a>top-level browsing context</a>, or using other heuristics to
+              mitigate the fingerprinting risk.
+          </p>
+      </section>
+
+    <section id='privacy.history'>
+      <h3>Stored Exceptions are Stored History</h3>
+
+      <p>
+        A database of stored exceptions is effectively storing a
+        local history of the sites browsed by the user over time.
+        Separate databases are needed per user profile (and per incognito
+        session) and ought to be protected from observation. A user might
+        wish to clear stored exceptions, or clear the database as a whole,
+        but as a separate action from clearing the visible browser history.
+      </p>
+  </section>
+</section>
+
+  <section id="acks" class='appendix'>
+    <h2>Acknowledgements</h2>
+
+    <p>
+      This specification consists of input from many discussions within
+      and around the W3C Tracking Protection Working Group, along with
+      written contributions from
+      Adrian&nbsp;Bateman (Microsoft),
+      Justin&nbsp;Brookman (CDT),
+      Nick&nbsp;Doty (W3C/MIT),
+      Marcos&nbsp;Caceres (Mozilla),
+      Rob&nbsp;van&nbsp;Eijk (Invited Expert),
+      Roy&nbsp;T.&nbsp;Fielding (Adobe),
+      Vinay&nbsp;Goel (Adobe),
+      Tom&nbsp;Lowenthal (Mozilla),
+      Jonathan&nbsp;Mayer (Stanford),
+      Aleecia&nbsp;M.&nbsp;McDonald (Stanford),
+      Mike&nbsp;O'Neill (Baycloud Systems),
+      Matthias&nbsp;Schunter (Intel),
+      John&nbsp;Simpson (Consumer Watchdog),
+      David&nbsp;Singer (Apple),
+      Rigo&nbsp;Wenning (W3C/ERCIM),
+      Shane&nbsp;Wiley (Yahoo!),
+      and Andy&nbsp;Zeigler (Microsoft).
+    </p>
+    <p>
+      The DNT header field is based on the original <em>Do Not Track</em>
+      submission by Jonathan&nbsp;Mayer (Stanford), Arvind&nbsp;Narayanan
+      (Stanford), and Sid&nbsp;Stamm (Mozilla).
+      The JavaScript DOM property for <code>doNotTrack</code> is based on the
+      <em>Web Tracking Protection</em> submission by Andy&nbsp;Zeigler,
+      Adrian&nbsp;Bateman, and Eliot&nbsp;Graff (Microsoft).
+      Many thanks to Robin&nbsp;Berjon for ReSpec.js.
+    </p>
+  </section>
+
+  <section id="registrations" class='appendix'>
+    <h2>Registrations</h2>
+
+    <p>
+      The Internet media type <a>application/tracking-status+json</a> is
+      used for tracking status representations
+      (<a href="#status-representation" class="sectionRef"></a>).
+    </p>
+    <dl>
+      <dt>Type name:</dt><dd>application</dd>
+      <dt>Subtype name:</dt><dd>tracking-status+json</dd>
+      <dt>Required parameters:</dt><dd>N/A</dd>
+      <dt>Optional parameters:</dt><dd>N/A</dd>
+      <dt>Encoding considerations:</dt><dd>binary</dd>
+      <dt>Security considerations:</dt>
+        <dd>See JSON [RFC7159], Section 12.</dd>
+      <dt>Interoperability considerations:</dt><dd>N/A</dd>
+      <dt>Published specification:</dt>
+        <dd>Tracking Preference Expression (DNT),
+          <a href="#status-representation" class="sectionRef"></a>.<br />
+          https://www.w3.org/TR/tracking-dnt/</dd>
+      <dt>Applications that use this media type:</dt><dd>N/A</dd>
+      <dt>Fragment identifier considerations:</dt><dd>N/A</dd>
+      <dt>Additional information:</dt>
+        <dd>
+          Deprecated alias names for this type: N/A<br />
+          Magic number(s): N/A<br />
+          File extension(s): N/A<br />
+          Macintosh file type code(s): N/A
+        </dd>
+      <dt>Person &amp; email address to contact for further information:</dt>
+        <dd>W3C Tracking Protection Working Group &lt;public-tracking@w3.org&gt;</dd>
+      <dt>Intended usage:</dt><dd>COMMON</dd>
+      <dt>Restrictions on usage:</dt><dd>N/A</dd>
+      <dt>Author(s):</dt><dd>Roy T. Fielding and David Singer</dd>
+      <dt>Change controller:</dt><dd>W3C</dd>
+    </dl>
+  </section>
+</body>
+</html>


### PR DESCRIPTION
Note added to the Fingerprinting section describing a potential attack and suggesting limiting the number of site specific targets.
Changed the API calls to refer to "effective script origin" rather that "site domain", subresources can now use them.
Made the storeTrackingException for web-wide only allow targets as long as they are equal to the script origin rather (not the site domain)
Allowed the "site" parameter for navigator.trackingExceptionExists so script can confirm any exception it can store